### PR TITLE
chore: Update repo name references after the rename

### DIFF
--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 jobs:
   sync:
-    if: github.repository == 'grafana/explore-profiles'
+    if: github.repository == 'grafana/profiles-drilldown'
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/update-make-docs.yml
+++ b/.github/workflows/update-make-docs.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   main:
-    if: github.repository == 'grafana/explore-profiles'
+    if: github.repository == 'grafana/profiles-drilldown'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ All Grafana instances come with Profiles Drilldown plugin preinstalled.
 
 For more information, refer to the Profiles Drilldown documentation in [Grafana](https://grafana.com/docs/grafana/latest/explore/simplified-exploration/profiles/) or [Grafana Cloud](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/profiles/).
 
-To learn more about contributing to the documentation, refer to the [README](https://github.com/grafana/explore-profiles/blob/main/docs/README.md).
+To learn more about contributing to the documentation, refer to the [README](https://github.com/grafana/profiles-drilldown/blob/main/docs/README.md).
 The Profiles Drilldown documentation source files are in docs/sources.
 
 ### Development / Contributing

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Before a piece of work is finished, it should:
 
 ## Get started
 
-1. Clone the repository `git clone git@github.com:grafana/explore-profiles.git`
+1. Clone the repository `git clone git@github.com:grafana/profiles-drilldown.git`
 2. Install the dependencies: `yarn install`
 3. Build the plugin in dev mode: `yarn dev`
 4. Start the Grafana server (with static data): `yarn server:static`

--- a/docs/GRAFANA-CROSS-DEVELOPMENT.md
+++ b/docs/GRAFANA-CROSS-DEVELOPMENT.md
@@ -23,7 +23,7 @@ This section describes how you can set up your local development environment to 
 
 ```ini
 [paths]
-plugins = /path/to/the/explore-profiles/folder
+plugins = /path/to/the/profiles-drilldown/folder
 ```
 
 The [plugins option](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#plugins) lets you customize where Grafana will look for plugins.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ The Profiles Drilldown documentation is written using the CommonMark flavor of m
 
 If you have a GitHub account and you're just making a small fix, for example fixing a typo or updating an example, you can edit the topic in GitHub.
 
-1. Find the topic in the explore-profiles repo.
+1. Find the topic in the profiles-drilldown repo.
 2. Click the pencil icon.
 3. Enter your changes.
 4. Click **Commit changes**. GitHub creates a pull request for you.

--- a/src/README.md
+++ b/src/README.md
@@ -33,26 +33,26 @@ For instructions installing, refer to the [access and installation instructions]
 ## Resources
 
 - [Documentation](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/profiles/)
-- [CHANGELOG](https://github.com/grafana/explore-profiles/releases)
-- [GITHUB](https://github.com/grafana/explore-profiles/)
+- [CHANGELOG](https://github.com/grafana/profiles-drilldown/releases)
+- [GITHUB](https://github.com/grafana/profiles-drilldown/)
 
 ## Contributing
 
 We love accepting contributions!
 If your change is minor, please feel free submit
-a [pull request](https://github.com/grafana/explore-profiles/pull/new)
+a [pull request](https://github.com/grafana/profiles-drilldown/pull/new)
 If your change is larger, or adds a feature, please file an issue beforehand so
 that we can discuss the change. You're welcome to file an implementation pull
 request immediately as well, although we generally lean towards discussing the
 change and then reviewing the implementation separately.
 
-For more information, refer to [Contributing to Grafana Profiles Drilldown](https://github.com/grafana/explore-profiles/blob/main/docs/CONTRIBUTING.md)
+For more information, refer to [Contributing to Grafana Profiles Drilldown](https://github.com/grafana/profiles-drilldown/blob/main/docs/CONTRIBUTING.md)
 
 ### Bugs
 
-If your issue is a bug, please open one [here](https://github.com/grafana/explore-profiles/issues/new).
+If your issue is a bug, please open one [here](https://github.com/grafana/profiles-drilldown/issues/new).
 
 ### Changes
 
 We do not have a formal proposal process for changes or feature requests. If you have a change you would like to see in
-Grafana Profiles Drilldown, please [file an issue](https://github.com/grafana/explore-profiles/issues/new) with the necessary details.
+Grafana Profiles Drilldown, please [file an issue](https://github.com/grafana/profiles-drilldown/issues/new) with the necessary details.

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -31,11 +31,11 @@
     "links": [
       {
         "name": "GitHub",
-        "url": "https://github.com/grafana/explore-profiles"
+        "url": "https://github.com/grafana/profiles-drilldown"
       },
       {
         "name": "Report bug",
-        "url": "https://github.com/grafana/explore-profiles/issues/new"
+        "url": "https://github.com/grafana/profiles-drilldown/issues/new"
       }
     ]
   },

--- a/src/shared/components/QueryBuilder/ui/inputs/SingleEditionInput.tsx
+++ b/src/shared/components/QueryBuilder/ui/inputs/SingleEditionInput.tsx
@@ -21,7 +21,7 @@ export function SingleEditionInput({ placeholder, defaultValue, onFocus, onChang
     const value = (e.target as HTMLInputElement).value.trim();
 
     // TODO: introduce an "is empty" value to handle this case (so that the filter will be synced in the URL)?
-    // see https://github.com/grafana/explore-profiles/pull/205
+    // see https://github.com/grafana/profiles-drilldown/pull/205
     if (e.code === 'Enter') {
       if (value) {
         onChange({ value, label: value });

--- a/src/shared/pyroscope-api/vcs/v1/vcs_pb.ts
+++ b/src/shared/pyroscope-api/vcs/v1/vcs_pb.ts
@@ -68,7 +68,7 @@ export type GithubLoginResponse = Message<"vcs.v1.GithubLoginResponse"> & {
    * In future version, this cookie won't be sent. Now, old cookie is sent alongside the new expected
    * data (token, token_expires_at and refresh_token_expires_at). Frontend will be responsible of computing
    * its own cookie from the new data.
-   * Remove after completing https://github.com/grafana/profiles-drilldown/issues/187
+   * Remove after completing https://github.com/grafana/explore-profiles/issues/187
    *
    * @generated from field: string cookie = 1;
    */

--- a/src/shared/pyroscope-api/vcs/v1/vcs_pb.ts
+++ b/src/shared/pyroscope-api/vcs/v1/vcs_pb.ts
@@ -68,7 +68,7 @@ export type GithubLoginResponse = Message<"vcs.v1.GithubLoginResponse"> & {
    * In future version, this cookie won't be sent. Now, old cookie is sent alongside the new expected
    * data (token, token_expires_at and refresh_token_expires_at). Frontend will be responsible of computing
    * its own cookie from the new data.
-   * Remove after completing https://github.com/grafana/explore-profiles/issues/187
+   * Remove after completing https://github.com/grafana/profiles-drilldown/issues/187
    *
    * @generated from field: string cookie = 1;
    */

--- a/src/shared/ui/PluginInfo.tsx
+++ b/src/shared/ui/PluginInfo.tsx
@@ -8,7 +8,7 @@ import { GIT_COMMIT } from '../../version';
 import { PyroscopeLogo } from './PyroscopeLogo';
 
 const pluginCommitSha: string = GIT_COMMIT;
-const pluginCommitURL = `https://github.com/grafana/explore-profiles/commit/${pluginCommitSha}`;
+const pluginCommitURL = `https://github.com/grafana/profiles-drilldown/commit/${pluginCommitSha}`;
 
 const { buildInfo: grafanaBuildInfo } = config;
 
@@ -47,12 +47,12 @@ function InfoMenu() {
       <Menu.Item
         label="Changelog"
         icon="list-ul"
-        onClick={() => window.open('https://github.com/grafana/explore-profiles/blob/main/CHANGELOG.md')}
+        onClick={() => window.open('https://github.com/grafana/profiles-drilldown/blob/main/CHANGELOG.md')}
       />
       <Menu.Item
         label="Contribute"
         icon="external-link-alt"
-        onClick={() => window.open('https://github.com/grafana/explore-profiles/blob/main/docs/CONTRIBUTING.md')}
+        onClick={() => window.open('https://github.com/grafana/profiles-drilldown/blob/main/docs/CONTRIBUTING.md')}
       />
       <Menu.Item
         label="Documentation"
@@ -62,7 +62,7 @@ function InfoMenu() {
       <Menu.Item
         label="Report an issue"
         icon="bug"
-        onClick={() => window.open('https://github.com/grafana/explore-profiles/issues/new?template=bug_report.md')}
+        onClick={() => window.open('https://github.com/grafana/profiles-drilldown/issues/new?template=bug_report.md')}
       />
       <Menu.Divider />
       <Menu.Item


### PR DESCRIPTION
### ✨ Description

Renames references to the repo name with the name

### 🧪 How to test?

The build should pass and the app should load normally. Links to repo in plugin info should work as expected.
