### PR TITLE
feat: Add a github callback view

### DIFF
--- a/src/app/Routes.tsx
+++ b/src/app/Routes.tsx
@@ -3,6 +3,7 @@ import { Navigate, Routes as ReactRouterRoutes, Route } from 'react-router-dom';
 
 import { PLUGIN_BASE_URL, ROUTES } from '../constants';
 import AdHocView from '../pages/AdHocView/AdHocView';
+import GitHubCallback from '../pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/ui/GitHubCallbackView';
 import ProfilesExplorerView from '../pages/ProfilesExplorerView/ProfilesExplorerView';
 import RecordingRulesView from '../pages/RecordingRulesView/RecordingRulesView';
 import SettingsView from '../pages/SettingsView/SettingsView';
@@ -14,6 +15,7 @@ export function Routes() {
       <Route path={ROUTES.ADHOC} element={<AdHocView />} />
       <Route path={ROUTES.SETTINGS} element={<SettingsView />} />
       <Route path={ROUTES.RECORDING_RULES} element={<RecordingRulesView />} />
+      <Route path={ROUTES.GITHUB_CALLBACK} element={<GitHubCallback />} />
       {/* Default Route */}
       <Route path="/*" element={<Navigate to={`${PLUGIN_BASE_URL}${ROUTES.EXPLORE}`} replace />} />
     </ReactRouterRoutes>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,4 +9,5 @@ export enum ROUTES {
   ADHOC = '/ad-hoc',
   SETTINGS = '/settings',
   RECORDING_RULES = '/recording-rules',
+  GITHUB_CALLBACK = '/github/callback',
 }

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/domain/openLoginPopup.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/domain/openLoginPopup.ts
@@ -1,13 +1,23 @@
-function buildGitHubAuthURL(clientID: string, nonce: string): string {
-  const url = new URL('/login/oauth/authorize', 'https://github.com');
+import { config } from '@grafana/runtime';
 
+import { PLUGIN_BASE_URL, ROUTES } from '../../../../../../../../../constants';
+
+function stripTrailingSlash(str: string): string {
+  return str.endsWith('/') ? str.slice(0, -1) : str;
+}
+
+function buildGitHubAuthURL(clientID: string, nonce: string): string {
+  const appSubUrl = stripTrailingSlash(config.appSubUrl || '/');
+  const redirectUri = `${window.location.origin}${appSubUrl}${PLUGIN_BASE_URL}${ROUTES.GITHUB_CALLBACK}`;
+
+  const url = new URL('/login/oauth/authorize', 'https://github.com');
   url.searchParams.set('client_id', clientID);
   url.searchParams.set('scope', 'repo');
   url.searchParams.set(
     'state',
     btoa(
       JSON.stringify({
-        redirect_uri: window.location.origin,
+        redirect_uri: redirectUri,
         nonce,
       })
     )

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/ui/GitHubCallbackView.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/ui/GitHubCallbackView.tsx
@@ -1,0 +1,58 @@
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Modal, Spinner, useStyles2 } from '@grafana/ui';
+import React, { useState } from 'react';
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  loadingIcon: css`
+    color: ${theme.colors.primary.main};
+    font-size: 48px;
+    margin-bottom: ${theme.spacing(2)};
+    display: flex;
+    justify-content: center;
+  `,
+  loadingMessage: css`
+    text-align: center;
+    font-size: ${theme.typography.h4.fontSize};
+    margin-bottom: ${theme.spacing(2)};
+  `,
+  fullScreenModal: css`
+    width: 100vw !important;
+    height: 100vh !important;
+    max-width: none !important;
+    max-height: none !important;
+    margin: 0 !important;
+    top: 0 !important;
+    left: 0 !important;
+    right: 0 !important;
+    bottom: 0 !important;
+  `,
+});
+
+export default function GitHubCallbackView() {
+  const styles = useStyles2(getStyles);
+  const [isModalOpen, setIsModalOpen] = useState(true);
+
+  const handleDismiss = () => {
+    setIsModalOpen(false);
+    window.close();
+  };
+
+  return (
+    <Modal
+      title="GitHub Login"
+      isOpen={isModalOpen}
+      onDismiss={handleDismiss}
+      closeOnEscape={true}
+      closeOnBackdropClick={true}
+      className={styles.fullScreenModal}
+    >
+      <div className={styles.loadingMessage}>
+        <div className={styles.loadingIcon}>
+          <Spinner size="xl" />
+        </div>
+        <p>Logging in to GitHub...</p>
+      </div>
+    </Modal>
+  );
+}


### PR DESCRIPTION
Currently we basically just show the naked domain (which results being
the cloud home page in Grafana Cloud). This change will make sure we
route this correctly to a view, which basically waits for login.
