### PR TITLE
feat: Lazy load entire app

### DIFF
--- a/src/app/Root.tsx
+++ b/src/app/Root.tsx
@@ -1,0 +1,11 @@
+import React, { Suspense } from 'react';
+
+const LazyApp = React.lazy(() => import('./App').then((module) => ({ default: module.App })));
+
+export function Root() {
+  return (
+    <Suspense>
+      <LazyApp />
+    </Suspense>
+  );
+}

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,10 +1,10 @@
 import { AppPlugin } from '@grafana/data';
 import { AppPluginSettings } from '@shared/types/AppPluginSettings';
 
-import { App } from './app/App';
+import { Root } from './app/Root';
 import { EXPLORE_TOOLBAR_ACTION, PluginExtensionExploreContext, TRACEVIEW_DETAILS_ACTION } from './links';
 
 export const plugin = new AppPlugin<AppPluginSettings>()
   .addLink<PluginExtensionExploreContext>(EXPLORE_TOOLBAR_ACTION)
   .addLink<PluginExtensionExploreContext>(TRACEVIEW_DETAILS_ACTION)
-  .setRootPage(App);
+  .setRootPage(Root);


### PR DESCRIPTION
### ✨ Description

Fixes: #423 

See https://raintank-corp.slack.com/archives/C048VSWPZ4P/p1745522343367069

This lazily loads the Profiles Drilldown app so it doesn't negatively impact other pages within Grafana. Example of loading a blank dashboard (having nothing to do with Profiles Drilldown) which loads the entire Profiles Drilldown app.

![image](https://github.com/user-attachments/assets/cfd282e8-6805-4606-81c2-04297708b89a)

