### PR TITLE
chore(ci): Fix uploading artifacts

### DIFF
--- a/.github/workflows/cut-new-release.yml
+++ b/.github/workflows/cut-new-release.yml
@@ -88,6 +88,7 @@ jobs:
     with:
       version: ${{ needs.create-new-version.outputs.version }}
       github_environment: gcs-no-approval
+      upload_github_artifact: true
 
   upload-latest:
     name: Upload latest tag to GCS

--- a/.github/workflows/release-existing-version.yml
+++ b/.github/workflows/release-existing-version.yml
@@ -29,6 +29,7 @@ jobs:
     with:
       version: ${{ inputs.version }}
       github_environment: gcs-no-approval
+      upload_github_artifact: true
 
   create-github-release:
     name: Create GitHub release

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -10,6 +10,11 @@ on:
       github_environment:
         required: true
         type: string
+      upload_github_artifact:
+        required: false
+        default: false
+        type: boolean
+        description: 'Additionally uploads the artifact to GitHub artifacts if needed by next steps - used only for creating GitHub release'
 
 jobs:
   upload:
@@ -68,7 +73,7 @@ jobs:
           predefinedAcl: publicRead
 
       - uses: actions/upload-artifact@v4
-        if: always()
+        if: ${{ inputs.upload_github_artifact }}
         with:
           name: build-upload
           path: ${{ steps.metadata.outputs.archive_name }}


### PR DESCRIPTION
### ✨ Description

Fixes issues when uploading https://github.com/grafana/profiles-drilldown/actions/runs/14659481025/job/41140864301

Upload GitHub action uploads to GCS + GitHub artifacts, but we cannot create artifacts with the same name. The GitHub artifact is now used only for creating a GitHub release so we can actually run it only when making a new release.