### PR TITLE
chore(CI): Fix app name used when committing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   build:
     name: Build and test
-    if: github.actor != 'databases-frontend-ci-bot[bot]'
+    if: github.actor != 'profiles-drilldown-ci[bot]'
     uses: ./.github/workflows/build.yml
     with:
       e2e: true

--- a/.github/workflows/cut-new-release.yml
+++ b/.github/workflows/cut-new-release.yml
@@ -66,13 +66,12 @@ jobs:
         id: tag
         env:
           INPUTS_VERSION: ${{ inputs.version }}
-          DB_FE_CI_BOT_EMAIL: ${{ secrets.DB_FE_CI_BOT_EMAIL }}
           STEPS_GET_INSTALLATION_TOKEN_OUTPUTS_TOKEN: ${{ steps.get_installation_token.outputs.token }}
         # Note: We don't get the version with VERSION=$(npm version ${{ inputs.version }})
         # because npm version runs standard changelog that outputs additional text we cannot include in version
         run: |
-          git config --global user.email "$DB_FE_CI_BOT_EMAIL"
-          git config --global user.name "Databases Frontend CI Bot"
+          git config --global user.email "profiles-drilldown-ci[bot]@users.noreply.github.com"
+          git config --global user.name "Profiles Drilldown CI"
           git config --global url."https://${STEPS_GET_INSTALLATION_TOKEN_OUTPUTS_TOKEN}@github.com/".insteadOf https://github.com/
           npm version ${INPUTS_VERSION}
           VERSION=$(git describe --tags --abbrev=0)


### PR DESCRIPTION
### ✨ Description

- Fixes the name used to check branch protection rules
- Updates the email (though it's not used for protection rules)
- Updates skipping CI workflow when changes are triggered by the release
