### PR TITLE
feat(Metrics from Profiles): Allow creating recording rules for all services

### DIFF
--- a/e2e/config/constants.ts
+++ b/e2e/config/constants.ts
@@ -28,6 +28,10 @@ export const AUTH_FILE = path.join(process.cwd(), 'e2e', 'auth', 'user.json');
 
 /* Grafana Profiles Drilldown */
 
+/**
+ * If you're adding a new exploration type, please make sure to update the useCurrentServiceName() function
+ * @see src/pages/ProfilesExplorerView/components/SceneCreateMetricModal/SceneCreateRecordingRuleModal.tsx
+ */
 export enum ExplorationType {
   AllServices = 'all',
   ProfileTypes = 'profiles',

--- a/e2e/fixtures/pages/ExploreProfilesPage.ts
+++ b/e2e/fixtures/pages/ExploreProfilesPage.ts
@@ -77,8 +77,24 @@ export class ExploreProfilesPage extends PyroscopePage {
 
   /* Header elements */
 
-  get viewRecordingRulesButton() {
-    return this.getByLabel('View recording rules');
+  get recordingRulesButton() {
+    return this.getByLabel('Recording rules');
+  }
+
+  clickOnViewRecordingRulesButton() {
+    return this.recordingRulesButton.click();
+  }
+
+  get addRecordingRuleButton() {
+    return this.getByLabel('Add recording rule');
+  }
+
+  async clickOnAddRecordingRuleButton() {
+    return this.addRecordingRuleButton.click();
+  }
+
+  get recordingRulesModalServiceName() {
+    return this.getByTestId('Create recording rule modal service name field');
   }
 
   /* Service */

--- a/e2e/tests/settings-view/settings-view.spec.ts
+++ b/e2e/tests/settings-view/settings-view.spec.ts
@@ -25,7 +25,7 @@ test.describe('Plugin Settings', () => {
     test('is not available by default', async ({ exploreProfilesPage }) => {
       await exploreProfilesPage.goto(ExplorationType.FlameGraph);
 
-      await expect(exploreProfilesPage.viewRecordingRulesButton).not.toBeVisible();
+      await expect(exploreProfilesPage.recordingRulesButton).not.toBeVisible();
 
       await exploreProfilesPage.clickOnFlameGraphNode({ x: 250, y: 10 });
       await expect(exploreProfilesPage.getFlameGraphContextualMenuItem('Create recording rule')).not.toBeVisible();
@@ -38,10 +38,38 @@ test.describe('Plugin Settings', () => {
       await expect(settingsPage.getSuccessAlertDialog()).toBeVisible();
 
       await exploreProfilesPage.goto(ExplorationType.FlameGraph);
-      await expect(exploreProfilesPage.viewRecordingRulesButton).toBeVisible();
+      await expect(exploreProfilesPage.recordingRulesButton).toBeVisible();
 
       await exploreProfilesPage.clickOnFlameGraphNode({ x: 250, y: 10 });
       await expect(exploreProfilesPage.getFlameGraphContextualMenuItem('Create recording rule')).toBeVisible();
+    });
+
+    test('create a recording rule for all services', async ({ settingsPage, exploreProfilesPage }) => {
+      await settingsPage.getMetricsFromProfilesCheckbox().click();
+      await settingsPage.getSaveSettingsButton().click();
+      await expect(settingsPage.getSuccessAlertDialog()).toBeVisible();
+
+      await exploreProfilesPage.goto(ExplorationType.AllServices);
+      await expect(exploreProfilesPage.recordingRulesButton).toBeVisible();
+      await exploreProfilesPage.clickOnViewRecordingRulesButton();
+      await expect(exploreProfilesPage.addRecordingRuleButton).toBeVisible();
+      await exploreProfilesPage.clickOnAddRecordingRuleButton();
+
+      await expect(exploreProfilesPage.recordingRulesModalServiceName).toContainText('All services');
+    });
+
+    test('create a recording rule for a single service', async ({ settingsPage, exploreProfilesPage }) => {
+      await settingsPage.getMetricsFromProfilesCheckbox().click();
+      await settingsPage.getSaveSettingsButton().click();
+      await expect(settingsPage.getSuccessAlertDialog()).toBeVisible();
+
+      await exploreProfilesPage.goto(ExplorationType.ProfileTypes);
+      await expect(exploreProfilesPage.recordingRulesButton).toBeVisible();
+      await exploreProfilesPage.clickOnViewRecordingRulesButton();
+      await expect(exploreProfilesPage.addRecordingRuleButton).toBeVisible();
+      await exploreProfilesPage.clickOnAddRecordingRuleButton();
+
+      await expect(exploreProfilesPage.recordingRulesModalServiceName).toContainText('ride-sharing-app');
     });
   });
 

--- a/src/pages/ProfilesExplorerView/components/SceneCreateMetricModal/SceneCreateRecordingRuleModal.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneCreateMetricModal/SceneCreateRecordingRuleModal.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
-import { Button, Divider, Field, Input, Modal, MultiSelect, useStyles2 } from '@grafana/ui';
+import { Button, Divider, Field, Input, Modal, MultiSelect, Text, useStyles2 } from '@grafana/ui';
 import { labelsRepository } from '@shared/infrastructure/labels/labelsRepository';
 import { getProfileMetric, ProfileMetricId } from '@shared/infrastructure/profile-metrics/getProfileMetric';
 import { RecordingRuleViewModel } from '@shared/types/RecordingRuleViewModel';
@@ -11,6 +11,8 @@ import { Controller, FieldError, SubmitHandler, useForm } from 'react-hook-form'
 import { FiltersVariable } from '../../domain/variables/FiltersVariable/FiltersVariable';
 import { ProfileMetricVariable } from '../../domain/variables/ProfileMetricVariable';
 import { ServiceNameVariable } from '../../domain/variables/ServiceNameVariable/ServiceNameVariable';
+import { ExplorationType, SceneProfilesExplorer } from '../SceneProfilesExplorer/SceneProfilesExplorer';
+import { useCreateRecordingRule } from './domain/useCreateRecordingRule';
 
 interface RecordingRuleForm {
   metricName: string;
@@ -22,6 +24,22 @@ interface RecordingRuleForm {
 
 interface SceneCreateRecordingRuleModalState extends SceneObjectState {}
 
+/**
+ * Returns the service name visible to the user. Takes into account views were service name is not visible (though
+ * still may be selected of be part of the URL).
+ */
+function useCurrentServiceName(model: SceneCreateRecordingRuleModal) {
+  const serviceNameVariable = sceneGraph.findByKeyAndType(model, 'serviceName', ServiceNameVariable);
+  const serviceName = serviceNameVariable.state.value;
+
+  const explorationType = sceneGraph
+    .findByKeyAndType(model, 'profiles-explorer', SceneProfilesExplorer)
+    .useState().explorationType;
+  return explorationType === ExplorationType.ALL_SERVICES || explorationType === ExplorationType.FAVORITES
+    ? undefined
+    : serviceName;
+}
+
 export class SceneCreateRecordingRuleModal extends SceneObjectBase<SceneCreateRecordingRuleModalState> {
   constructor() {
     super({});
@@ -31,11 +49,11 @@ export class SceneCreateRecordingRuleModal extends SceneObjectBase<SceneCreateRe
     model,
     isModalOpen,
     onDismiss,
-    onCreate,
+    onCreated,
   }: SceneComponentProps<SceneCreateRecordingRuleModal> & {
     isModalOpen: boolean;
     onDismiss: () => void;
-    onCreate: (rule: RecordingRuleViewModel) => Promise<void>;
+    onCreated: () => void;
   }) => {
     const {
       register,
@@ -46,25 +64,29 @@ export class SceneCreateRecordingRuleModal extends SceneObjectBase<SceneCreateRe
 
     const [options, setOptions] = useState<string[]>([]);
 
+    const { actions } = useCreateRecordingRule();
+
     const profileMetricVariable = sceneGraph.findByKeyAndType(model, 'profileMetricId', ProfileMetricVariable);
     const profileMetric = getProfileMetric(profileMetricVariable.state.value as ProfileMetricId);
 
-    const serviceNameVariable = sceneGraph.findByKeyAndType(model, 'serviceName', ServiceNameVariable);
-    const serviceName = serviceNameVariable.state.value;
+    const serviceName = useCurrentServiceName(model);
 
     const filtersVariable = sceneGraph.findByKeyAndType(model, 'filters', FiltersVariable);
     const filters = filtersVariable.state.filters;
     const filterQuery = filters.map((filter) => `${filter.key}${filter.operator}"${filter.value}"`).join(', ');
 
-    const onSubmit: SubmitHandler<RecordingRuleForm> = (data) =>
-      onCreate({
+    const onSubmit: SubmitHandler<RecordingRuleForm> = async (data) => {
+      const rule: RecordingRuleViewModel = {
         id: '',
         metricName: data.metricName,
         serviceName: data.serviceName,
         profileType: data.profileType,
         matchers: [`{${filterQuery}}`],
         groupBy: data.labels ? data.labels.map((label) => label.value ?? '') : [],
-      });
+      };
+      await actions.save(rule);
+      onCreated();
+    };
 
     useEffect(() => {
       const timeRange = sceneGraph.getTimeRange(model).state.value;
@@ -80,7 +102,12 @@ export class SceneCreateRecordingRuleModal extends SceneObjectBase<SceneCreateRe
     }, [filterQuery, model]);
 
     return (
-      <Modal title="Create recording rule" isOpen={isModalOpen} onDismiss={onDismiss}>
+      <Modal
+        title="Create recording rule"
+        isOpen={isModalOpen}
+        onDismiss={onDismiss}
+        data-testid="Create recording rule modal"
+      >
         <form onSubmit={handleSubmit(onSubmit)}>
           <Field
             label="Metric name"
@@ -89,7 +116,7 @@ export class SceneCreateRecordingRuleModal extends SceneObjectBase<SceneCreateRe
             invalid={!!errors.metricName}
           >
             <Input
-              placeholder={`pyroscope_metric_${profileMetric.type}_${serviceName
+              placeholder={`pyroscope_metric_${profileMetric.type}_${(serviceName || 'name')
                 .toString()
                 .replace(/[^a-zA-Z0-9_]/g, '_')}`}
               required
@@ -125,10 +152,17 @@ export class SceneCreateRecordingRuleModal extends SceneObjectBase<SceneCreateRe
 
           <Divider />
 
-          <Field label="Service name">
-            <div>{`${serviceName}`}</div>
+          <Field label="Service name" data-testid="Create recording rule modal service name field">
+            {serviceName ? (
+              <div>{`${serviceName}`}</div>
+            ) : (
+              <Text element="span" color="secondary">
+                All services
+              </Text>
+            )}
           </Field>
-          <input type="text" value={serviceName.toString()} hidden {...register('serviceName')} />
+
+          <input type="text" value={serviceName?.toString()} hidden {...register('serviceName')} />
 
           <Field label="Profile type">
             <div>{`${profileMetric.group}/${profileMetric.type}`}</div>
@@ -140,7 +174,7 @@ export class SceneCreateRecordingRuleModal extends SceneObjectBase<SceneCreateRe
           </Field>
 
           <Modal.ButtonRow>
-            <Button variant="secondary" fill="outline" onClick={onDismiss}>
+            <Button variant="secondary" fill="outline" onClick={onDismiss} aria-label="Cancel">
               Cancel
             </Button>
             <Button variant="primary" type="submit">

--- a/src/pages/ProfilesExplorerView/components/SceneCreateMetricModal/SceneCreateRecordingRuleModal.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneCreateMetricModal/SceneCreateRecordingRuleModal.tsx
@@ -25,8 +25,11 @@ interface RecordingRuleForm {
 interface SceneCreateRecordingRuleModalState extends SceneObjectState {}
 
 /**
- * Returns the service name visible to the user. Takes into account views were service name is not visible (though
- * still may be selected of be part of the URL).
+ * Returns the service name if a service name dropdown is visible on the screen for the user.
+ *
+ * In "All services" and "Favorites" exploration types, the service name is not shown on the screen,
+ * though the variable is still present in the URL so we need to check explicitly what's the current
+ * exploration type instead of just reading the variable name.
  */
 function useCurrentServiceName(model: SceneCreateRecordingRuleModal) {
   const serviceNameVariable = sceneGraph.findByKeyAndType(model, 'serviceName', ServiceNameVariable);

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
@@ -10,7 +10,6 @@ import { getProfileMetric, ProfileMetricId } from '@shared/infrastructure/profil
 import { featureToggles } from '@shared/infrastructure/settings/featureToggles';
 import { useFetchPluginSettings } from '@shared/infrastructure/settings/useFetchPluginSettings';
 import { DomainHookReturnValue } from '@shared/types/DomainHookReturnValue';
-import { RecordingRuleViewModel } from '@shared/types/RecordingRuleViewModel';
 import { InlineBanner } from '@shared/ui/InlineBanner';
 import { Panel } from '@shared/ui/Panel/Panel';
 import { PyroscopeLogo } from '@shared/ui/PyroscopeLogo';
@@ -23,7 +22,6 @@ import { buildFlameGraphQueryRunner } from '../../infrastructure/flame-graph/bui
 import { PYROSCOPE_DATA_SOURCE } from '../../infrastructure/pyroscope-data-sources';
 import { AIButton } from '../SceneAiPanel/components/AiButton/AIButton';
 import { SceneAiPanel } from '../SceneAiPanel/SceneAiPanel';
-import { useCreateRecordingRule } from '../SceneCreateMetricModal/domain/useCreateRecordingRule';
 import { useCreateRecordingRulesMenu } from '../SceneCreateMetricModal/domain/useMenuOption';
 import { SceneCreateRecordingRuleModal } from '../SceneCreateMetricModal/SceneCreateRecordingRuleModal';
 import { SceneExportMenu } from './components/SceneExportMenu/SceneExportMenu';
@@ -184,7 +182,6 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
 
     const { settings } = useFetchPluginSettings();
 
-    const { actions: recordingRulesActions } = useCreateRecordingRule();
     const [recordingRulesModelOpen, setIsRecordingRulesModalOpen] = useState(false);
     const recordingRulesMenu = useCreateRecordingRulesMenu(() => setIsRecordingRulesModalOpen(true));
 
@@ -277,8 +274,7 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
           model={data.recordingRules.modal}
           isModalOpen={recordingRulesModelOpen}
           onDismiss={() => setIsRecordingRulesModalOpen(false)}
-          onCreate={(rule: RecordingRuleViewModel) => {
-            recordingRulesActions.save(rule);
+          onCreated={() => {
             setIsRecordingRulesModalOpen(false);
           }}
         />

--- a/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/SceneProfilesExplorer.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/SceneProfilesExplorer.tsx
@@ -20,7 +20,7 @@ import { displayError } from '@shared/domain/displayStatus';
 import { prepareHistoryEntry } from '@shared/domain/prepareHistoryEntry';
 import { reportInteraction } from '@shared/domain/reportInteraction';
 import { DomainHookReturnValue } from '@shared/types/DomainHookReturnValue';
-import React from 'react';
+import React, { useState } from 'react';
 
 import { SceneExploreAllServices } from '../../components/SceneExploreAllServices/SceneExploreAllServices';
 import { SceneExploreFavorites } from '../../components/SceneExploreFavorites/SceneExploreFavorites';
@@ -45,6 +45,7 @@ import { SceneNoDataSwitcher } from '../SceneByVariableRepeaterGrid/components/S
 import { ScenePanelTypeSwitcher } from '../SceneByVariableRepeaterGrid/components/ScenePanelTypeSwitcher';
 import { SceneQuickFilter } from '../SceneByVariableRepeaterGrid/components/SceneQuickFilter';
 import { GridItemData } from '../SceneByVariableRepeaterGrid/types/GridItemData';
+import { SceneCreateRecordingRuleModal } from '../SceneCreateMetricModal/SceneCreateRecordingRuleModal';
 import { SceneExploreDiffFlameGraph } from '../SceneExploreDiffFlameGraph/SceneExploreDiffFlameGraph';
 import { GitHubContextProvider } from '../SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/GitHubContextProvider';
 import { RemoveSpanSelector } from '../SceneExploreServiceFlameGraph/domain/events/RemoveSpanSelector';
@@ -57,6 +58,7 @@ export interface SceneProfilesExplorerState extends Partial<EmbeddedSceneState> 
   gridControls: Array<SceneObject & { key?: string }>;
   explorationType?: ExplorationType;
   body?: SplitLayout;
+  createRecordingRuleModal: SceneCreateRecordingRuleModal;
 }
 
 export enum ExplorationType {
@@ -130,6 +132,7 @@ export class SceneProfilesExplorer extends SceneObjectBase<SceneProfilesExplorer
           new SpanSelectorVariable(),
         ],
       }),
+      createRecordingRuleModal: new SceneCreateRecordingRuleModal(),
       controls: [new SceneTimePicker({ isOnCanvas: true }), new SceneRefreshPicker({ isOnCanvas: true })],
       // these scenes also sync with the URL so...
       // ...because of a limitation of the Scenes library, we have to create them now, once, and not every time we set a new exploration type
@@ -415,6 +418,10 @@ export class SceneProfilesExplorer extends SceneObjectBase<SceneProfilesExplorer
     const { data, actions } = model.useProfilesExplorer();
     const { explorationType, controls, body, $variables, dataSourceUid } = data;
 
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [recordingRulesModelOpen, setIsRecordingRulesModalOpen] = useState(false);
+    const { createRecordingRuleModal } = model.useState();
+
     return (
       <GitHubContextProvider dataSourceUid={dataSourceUid}>
         <Header
@@ -423,11 +430,23 @@ export class SceneProfilesExplorer extends SceneObjectBase<SceneProfilesExplorer
           body={body}
           $variables={$variables}
           onChangeExplorationType={actions.onChangeExplorationType}
+          onCreateRecordingRule={() => {
+            setIsRecordingRulesModalOpen(true);
+          }}
         />
 
         <div className={styles.body} data-testid="sceneBody">
           {body && <body.Component model={body} />}
         </div>
+
+        <SceneCreateRecordingRuleModal.Component
+          model={createRecordingRuleModal}
+          isModalOpen={recordingRulesModelOpen}
+          onDismiss={() => setIsRecordingRulesModalOpen(false)}
+          onCreated={() => {
+            setIsRecordingRulesModalOpen(false);
+          }}
+        />
       </GitHubContextProvider>
     );
   }

--- a/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/components/Header.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/components/Header.tsx
@@ -1,7 +1,7 @@
 import { css, cx } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { useChromeHeaderHeight } from '@grafana/runtime';
-import { Field, Icon, IconButton, useStyles2 } from '@grafana/ui';
+import { Dropdown, Field, Icon, IconButton, Menu, useStyles2 } from '@grafana/ui';
 import { featureToggles } from '@shared/infrastructure/settings/featureToggles';
 import { useFetchPluginSettings } from '@shared/infrastructure/settings/useFetchPluginSettings';
 import { PluginInfo } from '@shared/ui/PluginInfo';
@@ -18,6 +18,7 @@ export type HeaderProps = {
   body: SceneProfilesExplorerState['body'];
   $variables: SceneProfilesExplorerState['$variables'];
   onChangeExplorationType: (explorationType: string) => void;
+  onCreateRecordingRule: () => void;
 };
 
 export function Header(props: HeaderProps) {
@@ -30,6 +31,17 @@ export function Header(props: HeaderProps) {
 
   const { explorationType, dataSourceVariable, timePickerControl, refreshPickerControl, sceneVariables, gridControls } =
     data;
+
+  const metricsFromProfilesMenu = (
+    <Menu>
+      <Menu.Item
+        ariaLabel="View recording rules"
+        label="View recording rules"
+        onClick={actions.onClickRecordingRules}
+      />
+      <Menu.Item ariaLabel="Add recording rule" label="Add recording rule" onClick={props.onCreateRecordingRule} />
+    </Menu>
+  );
 
   return (
     <div className={styles.header} data-testid="allControls">
@@ -54,12 +66,11 @@ export function Header(props: HeaderProps) {
 
           <div className={styles.appMiscButtons}>
             {settings?.enableMetricsFromProfiles && featureToggles.metricsFromProfiles && (
-              <IconButton
-                name="gf-prometheus"
-                tooltip="View recording rules"
-                aria-label="View recording rules"
-                onClick={actions.onClickRecordingRules}
-              />
+              <>
+                <Dropdown overlay={metricsFromProfilesMenu}>
+                  <IconButton name="gf-prometheus" tooltip="Recording rules" aria-label="Recording rules" />
+                </Dropdown>
+              </>
             )}
 
             <IconButton name="upload" tooltip="Upload ad hoc profiles" onClick={actions.onClickAdHoc} />

--- a/src/pages/RecordingRulesView/RecordingRulesView.tsx
+++ b/src/pages/RecordingRulesView/RecordingRulesView.tsx
@@ -33,9 +33,11 @@ export default function RecordingRulesView() {
       cell: (props) => {
         const rule: RecordingRuleViewModel = props.row.original;
         return (
-          <Text element="span" color="secondary">
-            {rule.serviceName || 'All services'}
-          </Text>
+          rule.serviceName || (
+            <Text element="span" color="secondary">
+              All services
+            </Text>
+          )
         );
       },
     },

--- a/src/pages/RecordingRulesView/RecordingRulesView.tsx
+++ b/src/pages/RecordingRulesView/RecordingRulesView.tsx
@@ -30,6 +30,14 @@ export default function RecordingRulesView() {
       id: 'serviceName',
       header: 'Service Name',
       sortType: 'alphanumeric',
+      cell: (props) => {
+        const rule: RecordingRuleViewModel = props.row.original;
+        return (
+          <Text element="span" color="secondary">
+            {rule.serviceName || 'All services'}
+          </Text>
+        );
+      },
     },
     {
       id: 'profileType',

--- a/src/shared/types/RecordingRuleViewModel.ts
+++ b/src/shared/types/RecordingRuleViewModel.ts
@@ -1,7 +1,7 @@
 export type RecordingRuleViewModel = {
   id: string;
   metricName: string;
-  serviceName: string;
+  serviceName?: string;
   profileType: string;
   matchers: string[];
   groupBy: string[];


### PR DESCRIPTION
### ✨ Description

Fixes: https://github.com/grafana/profiles-drilldown/issues/498
Related issue(s): https://github.com/grafana/pyroscope-squad/issues/398

<!-- General summary of what the PR aims to do -->

### 📖 Summary of the changes

When clicking on the Prometheus icon the user can add a new recording rule. Depending on the exploration type it will use following data to populate the modal:

- All services: No service name + selected profile type
- Profile types: selected service name + **first profile type from the list**
- Labels / Flame Graph / Diff: selected service name + profile type
- Favorites: No service name + **first profile type from the list**

https://github.com/user-attachments/assets/7ea17cb7-b98b-4a69-9247-e2275b5bcb88

