### PR TITLE
feat(GitHub Integration): Keep GitHub auth cookie within the same session if the data source doesn't change

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/GitHubContextProvider.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/GitHubContextProvider.tsx
@@ -17,6 +17,9 @@ type GitHubContextProviderProps = {
 
 export const nonce = generateNonce();
 
+// Keep the data source UID in session storage to reuse it if the page is refreshed
+const SESSION_DATA_SOURCE_KEY = `grafana-pyroscope-app.gitHubIntegration.dataSourceUid`;
+
 export function GitHubContextProvider({ dataSourceUid, children }: GitHubContextProviderProps) {
   const vcsClient = DataSourceProxyClientBuilder.build(dataSourceUid, VcsClient);
   const privateVcsClient = DataSourceProxyClientBuilder.build(dataSourceUid, PrivateVcsClient);
@@ -29,10 +32,10 @@ export function GitHubContextProvider({ dataSourceUid, children }: GitHubContext
   // when logged in and changing data source
   // TODO: provide a better way
   useEffect(() => {
-    const gitHubIntegrationDataSourceUid = sessionStorage.getItem('gitHubIntegration.dataSourceUid');
+    const gitHubIntegrationDataSourceUid = sessionStorage.getItem(SESSION_DATA_SOURCE_KEY);
     if (gitHubIntegrationDataSourceUid !== dataSourceUid) {
       setSessionCookie('');
-      sessionStorage.setItem('gitHubIntegration.dataSourceUid', dataSourceUid || '');
+      sessionStorage.setItem(SESSION_DATA_SOURCE_KEY, dataSourceUid || '');
     }
   }, [dataSourceUid]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/GitHubContextProvider.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/GitHubContextProvider.tsx
@@ -29,7 +29,11 @@ export function GitHubContextProvider({ dataSourceUid, children }: GitHubContext
   // when logged in and changing data source
   // TODO: provide a better way
   useEffect(() => {
-    setSessionCookie('');
+    const gitHubIntegrationDataSourceUid = sessionStorage.getItem('gitHubIntegration.dataSourceUid');
+    if (gitHubIntegrationDataSourceUid !== dataSourceUid) {
+      setSessionCookie('');
+      sessionStorage.setItem('gitHubIntegration.dataSourceUid', dataSourceUid || '');
+    }
   }, [dataSourceUid]); // eslint-disable-line react-hooks/exhaustive-deps
 
   usePollGitHubPopup({ vcsClient, externalWindow, setExternalWindow, setSessionCookie, nonce });


### PR DESCRIPTION
### ✨ Description

Fixes: https://github.com/grafana/profiles-drilldown/issues/514

<!-- General summary of what the PR aims to do -->

### 📖 Summary of the changes

Keeps the auth cookie within the same session unless data source is changed. The user can refresh the page, navigate between various Grafana pages easily without the need to re-authenticate again.

Before:

https://github.com/user-attachments/assets/e9da0a65-69f7-40db-8d65-35eede505482

After:

https://github.com/user-attachments/assets/9dfe5a92-192b-4fa0-a54c-3fd4568e1a2e

### 🧪 How to test?

Set up GitHub integration (you can read more in https://grafana.com/docs/grafana-cloud/monitor-applications/profiles/pyroscope-github-integration/):

- Create a GitHub App (not OAuth app) in https://github.com/settings/apps
  - Copy clientID and create a new client secret
  - Use `http://localhost:3000/a/grafana-pyroscope-app/github/callback` as callback URL 
  - Set read-only permission to "Contents", "Custom properties" and "Pull requests"
- Run Pyroscope with GitHub integration configured:
  - Run `GITHUB_CLIENT_ID=YOUR_CLIENT_ID GITHUB_CLIENT_SECRET=YOUR_CLIENT_SECRET GITHUB_SESSION_SECRET=ANY_RANDOM_STRING yarn server`
  - You can also run `GRAFANA_PORT=3001 GITHUB_CLIENT_ID=YOUR_CLIENT_ID GITHUB_CLIENT_SECRET=YOUR_CLIENT_SECRET GITHUB_SESSION_SECRET=ANY_RANDOM_STRING yarn server` to change the port Grafana is running to avoid conflicts with your local env but make sure you update the app callback URL accordingly
  - Or run Pyroscope from sources and add env variables in launch.json: 
  ```
      "env": {
        // env vars go here. For example:
        "GITHUB_CLIENT_ID": "YOUR_CLIENT_ID",
        "GITHUB_CLIENT_SECRET": "YOUR_CLIENT_SECRET",
        "GITHUB_SESSION_SECRET": "ANY_RANDOM_STRING"
      },
  ```