### PR TITLE
chore(e2e): Full flow e2e test for creating recording rules

### DIFF
--- a/e2e/fixtures/pages/ExploreProfilesPage.ts
+++ b/e2e/fixtures/pages/ExploreProfilesPage.ts
@@ -97,6 +97,51 @@ export class ExploreProfilesPage extends PyroscopePage {
     return this.getByTestId('Create recording rule modal service name field');
   }
 
+  get recordingRulesModalMetricName() {
+    return this.getByLabel('Metric name', { type: 'input' });
+  }
+
+  async fillRecordingRuleForm(options: { metricName?: string }) {
+    if (options.metricName) {
+      await this.recordingRulesModalMetricName.fill(options.metricName);
+    }
+  }
+
+  async submitRecordingRuleForm() {
+    await this.getByRole('button', { name: 'Create' }).click();
+  }
+
+  get recordingRulesDropdown() {
+    return this.getByLabel('Recording rules');
+  }
+
+  get recordingRulesViewRecordingRules() {
+    return this.getByLabel('View recording rules');
+  }
+
+  clickOnViewRecordingRulesDropdown() {
+    return this.recordingRulesDropdown.click();
+  }
+
+  clickOnViewRecordingRulesViewRecordingRules() {
+    return this.recordingRulesViewRecordingRules.click();
+  }
+
+  async goToRecordingRulesPage() {
+    await this.clickOnViewRecordingRulesDropdown();
+    await this.clickOnViewRecordingRulesViewRecordingRules();
+  }
+
+  async assertRecordingRuleInTable(metricName: string) {
+    const table = this.getRecordingRulesTable();
+    const row = table.locator('tr').filter({ hasText: metricName });
+    await expect(row).toBeVisible();
+  }
+
+  getRecordingRulesTable() {
+    return this.page.locator('table');
+  }
+
   /* Service */
 
   getServiceSelector() {

--- a/e2e/tests/recording-rules/recording-rules.spec.ts
+++ b/e2e/tests/recording-rules/recording-rules.spec.ts
@@ -1,0 +1,87 @@
+import { ExplorationType } from '../../config/constants';
+import { expect, test } from '../../fixtures';
+
+test.beforeEach(async ({ settingsPage }) => {
+  await settingsPage.goto();
+});
+
+test.afterEach(async ({ settingsPage }) => {
+  await settingsPage.resetTestSettings(false);
+});
+
+test.describe('Recording rules', () => {
+  // prevents unwanted settings modifications while running multiple tests in parallel
+  test.describe.configure({ mode: 'serial' });
+
+  test.describe('Settings', () => {
+    test('is not available by default', async ({ exploreProfilesPage }) => {
+      await exploreProfilesPage.goto(ExplorationType.FlameGraph);
+
+      await expect(exploreProfilesPage.recordingRulesButton).not.toBeVisible();
+
+      await exploreProfilesPage.clickOnFlameGraphNode({ x: 250, y: 10 });
+      await expect(exploreProfilesPage.getFlameGraphContextualMenuItem('Create recording rule')).not.toBeVisible();
+      await expect(exploreProfilesPage.getFlameGraphContextualMenuItem('Create recording rule')).not.toBeVisible();
+    });
+
+    test('can be enabled', async ({ settingsPage, exploreProfilesPage }) => {
+      await settingsPage.getMetricsFromProfilesCheckbox().click();
+      await settingsPage.getSaveSettingsButton().click();
+      await expect(settingsPage.getSuccessAlertDialog()).toBeVisible();
+
+      await exploreProfilesPage.goto(ExplorationType.FlameGraph);
+      await expect(exploreProfilesPage.recordingRulesButton).toBeVisible();
+
+      await exploreProfilesPage.clickOnFlameGraphNode({ x: 250, y: 10 });
+      await expect(exploreProfilesPage.getFlameGraphContextualMenuItem('Create recording rule')).toBeVisible();
+    });
+
+    test('create a recording rule for all services', async ({ settingsPage, exploreProfilesPage }) => {
+      await settingsPage.getMetricsFromProfilesCheckbox().click();
+      await settingsPage.getSaveSettingsButton().click();
+      await expect(settingsPage.getSuccessAlertDialog()).toBeVisible();
+
+      await exploreProfilesPage.goto(ExplorationType.AllServices);
+      await expect(exploreProfilesPage.recordingRulesButton).toBeVisible();
+      await exploreProfilesPage.clickOnViewRecordingRulesButton();
+      await expect(exploreProfilesPage.addRecordingRuleButton).toBeVisible();
+      await exploreProfilesPage.clickOnAddRecordingRuleButton();
+
+      await expect(exploreProfilesPage.recordingRulesModalServiceName).toContainText('All services');
+    });
+
+    test('create a recording rule for a single service', async ({ settingsPage, exploreProfilesPage }) => {
+      await settingsPage.getMetricsFromProfilesCheckbox().click();
+      await settingsPage.getSaveSettingsButton().click();
+      await expect(settingsPage.getSuccessAlertDialog()).toBeVisible();
+
+      await exploreProfilesPage.goto(ExplorationType.ProfileTypes);
+      await expect(exploreProfilesPage.recordingRulesButton).toBeVisible();
+      await exploreProfilesPage.clickOnViewRecordingRulesButton();
+      await expect(exploreProfilesPage.addRecordingRuleButton).toBeVisible();
+      await exploreProfilesPage.clickOnAddRecordingRuleButton();
+
+      await expect(exploreProfilesPage.recordingRulesModalServiceName).toContainText('ride-sharing-app');
+    });
+  });
+
+  test('Create and display', async ({ settingsPage, exploreProfilesPage }) => {
+    await settingsPage.getMetricsFromProfilesCheckbox().click();
+    await settingsPage.getSaveSettingsButton().click();
+    await expect(settingsPage.getSuccessAlertDialog()).toBeVisible();
+
+    await exploreProfilesPage.goto(ExplorationType.FlameGraph);
+    await exploreProfilesPage.clickOnFlameGraphNode({ x: 250, y: 10 });
+    await exploreProfilesPage.getFlameGraphContextualMenuItem('Create recording rule').click();
+
+    // Create rule with specific function name
+    await exploreProfilesPage.fillRecordingRuleForm({
+      metricName: 'test_specific_function_metric',
+    });
+    await exploreProfilesPage.submitRecordingRuleForm();
+
+    // Go to recording rules page and verify the function name is displayed
+    await exploreProfilesPage.goToRecordingRulesPage();
+    await exploreProfilesPage.assertRecordingRuleInTable('test_specific_function_metric');
+  });
+});

--- a/e2e/tests/settings-view/settings-view.spec.ts
+++ b/e2e/tests/settings-view/settings-view.spec.ts
@@ -21,58 +21,6 @@ test.describe('Plugin Settings', () => {
     await expect(flamegraphSettings.getByText('Maximum number of nodes')).toBeVisible();
   });
 
-  test.describe('Metrics from profiles settings', () => {
-    test('is not available by default', async ({ exploreProfilesPage }) => {
-      await exploreProfilesPage.goto(ExplorationType.FlameGraph);
-
-      await expect(exploreProfilesPage.recordingRulesButton).not.toBeVisible();
-
-      await exploreProfilesPage.clickOnFlameGraphNode({ x: 250, y: 10 });
-      await expect(exploreProfilesPage.getFlameGraphContextualMenuItem('Create recording rule')).not.toBeVisible();
-      await expect(exploreProfilesPage.getFlameGraphContextualMenuItem('Create recording rule')).not.toBeVisible();
-    });
-
-    test('can be enabled', async ({ settingsPage, exploreProfilesPage }) => {
-      await settingsPage.getMetricsFromProfilesCheckbox().click();
-      await settingsPage.getSaveSettingsButton().click();
-      await expect(settingsPage.getSuccessAlertDialog()).toBeVisible();
-
-      await exploreProfilesPage.goto(ExplorationType.FlameGraph);
-      await expect(exploreProfilesPage.recordingRulesButton).toBeVisible();
-
-      await exploreProfilesPage.clickOnFlameGraphNode({ x: 250, y: 10 });
-      await expect(exploreProfilesPage.getFlameGraphContextualMenuItem('Create recording rule')).toBeVisible();
-    });
-
-    test('create a recording rule for all services', async ({ settingsPage, exploreProfilesPage }) => {
-      await settingsPage.getMetricsFromProfilesCheckbox().click();
-      await settingsPage.getSaveSettingsButton().click();
-      await expect(settingsPage.getSuccessAlertDialog()).toBeVisible();
-
-      await exploreProfilesPage.goto(ExplorationType.AllServices);
-      await expect(exploreProfilesPage.recordingRulesButton).toBeVisible();
-      await exploreProfilesPage.clickOnViewRecordingRulesButton();
-      await expect(exploreProfilesPage.addRecordingRuleButton).toBeVisible();
-      await exploreProfilesPage.clickOnAddRecordingRuleButton();
-
-      await expect(exploreProfilesPage.recordingRulesModalServiceName).toContainText('All services');
-    });
-
-    test('create a recording rule for a single service', async ({ settingsPage, exploreProfilesPage }) => {
-      await settingsPage.getMetricsFromProfilesCheckbox().click();
-      await settingsPage.getSaveSettingsButton().click();
-      await expect(settingsPage.getSuccessAlertDialog()).toBeVisible();
-
-      await exploreProfilesPage.goto(ExplorationType.ProfileTypes);
-      await expect(exploreProfilesPage.recordingRulesButton).toBeVisible();
-      await exploreProfilesPage.clickOnViewRecordingRulesButton();
-      await expect(exploreProfilesPage.addRecordingRuleButton).toBeVisible();
-      await exploreProfilesPage.clickOnAddRecordingRuleButton();
-
-      await expect(exploreProfilesPage.recordingRulesModalServiceName).toContainText('ride-sharing-app');
-    });
-  });
-
   test.describe('Flame graph settings', () => {
     test('Can be modified', async ({ settingsPage, exploreProfilesPage }) => {
       await settingsPage.getCollapsedFlamegraphsCheckbox().click();

--- a/samples/static/pyroscope/config.yaml
+++ b/samples/static/pyroscope/config.yaml
@@ -7,3 +7,7 @@ storage:
 limits:
   max_query_length: 0
   max_query_lookback: 0
+
+tenant_settings:
+  recording_rules:
+    enabled: true

--- a/src/pages/ProfilesExplorerView/components/SceneCreateMetricModal/SceneCreateRecordingRuleModal.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneCreateMetricModal/SceneCreateRecordingRuleModal.tsx
@@ -122,6 +122,7 @@ export class SceneCreateRecordingRuleModal extends SceneObjectBase<SceneCreateRe
               placeholder={`pyroscope_metric_${profileMetric.type}_${(serviceName || 'name')
                 .toString()
                 .replace(/[^a-zA-Z0-9_]/g, '_')}`}
+              aria-label="Metric name"
               required
               autoFocus
               {...register('metricName', {


### PR DESCRIPTION
### ✨ Description

Related issue(s): #497

<!-- General summary of what the PR aims to do -->

### 📖 Summary of the changes

While working on #497 I figured I would need to add more e2e tests and realized some basic end to end scenario is missing. Creating a separate PR - this will reduce changes introduced for #497.

Tests from settings-view were extracted to a separate file + "Create and display" test was added.

### 🧪 How to test?

Tests should pass