### PR TITLE
ci: Add a workflow to publish a PR/branch

### DIFF
--- a/.github/workflows/plugins-pr.yml
+++ b/.github/workflows/plugins-pr.yml
@@ -28,6 +28,6 @@ jobs:
       branch: ${{ inputs.branch }}
       environment: dev
       # No grafana-cloud-deployment-type defined -> plugin will be published to the catalog, but not deployed to Grafana Cloud
-      # Skip tests (theu are run in the main PR/CI workflow)
+      # Skip tests (they are run in the main PR/CI workflow)
       run-playwright: false
       run-playwright-docker: false

--- a/.github/workflows/plugins-pr.yml
+++ b/.github/workflows/plugins-pr.yml
@@ -28,4 +28,6 @@ jobs:
       branch: ${{ inputs.branch }}
       environment: dev
       # No grafana-cloud-deployment-type defined -> plugin will be published to the catalog, but not deployed to Grafana Cloud
-
+      # Skip tests (theu are run in the main PR/CI workflow)
+      run-playwright: false
+      run-playwright-docker: false

--- a/.github/workflows/plugins-pr.yml
+++ b/.github/workflows/plugins-pr.yml
@@ -26,6 +26,6 @@ jobs:
       attestations: write
     with:
       branch: ${{ inputs.branch }}
-      environment: ops
+      environment: dev
       # No grafana-cloud-deployment-type defined -> plugin will be published to the catalog, but not deployed to Grafana Cloud
 

--- a/.github/workflows/plugins-pr.yml
+++ b/.github/workflows/plugins-pr.yml
@@ -1,0 +1,56 @@
+name: Plugins Platform Publish - CD
+run-name: Deploy ${{ inputs.branch }} to ${{ inputs.environment }} by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to publish from. Can be used to deploy PRs to dev
+        default: main
+      environment:
+        description: Environment to publish to
+        required: true
+        type: choice
+        options:
+          - 'dev'
+          - 'ops'
+      docs-only:
+        description: Only publish docs, do not publish the plugin
+        default: false
+        type: boolean
+
+# No global permissions, each job defines own scope
+permissions: {}
+
+jobs:
+  cd:
+    name: CI / CD
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main
+    # These are maximum permissions for the job and should match the permissions defined in the workflow
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    with:
+      # Checkout/build PR or main branch, depending on event
+      branch: ${{ github.event_name == 'push' && github.ref_name || github.ref }}
+
+      # When pushing to "main", publish and deploy to "dev" (CD). For PRs, skip publishing and deploying (run CI only)
+      environment: ${{ (github.event_name == 'push' && github.ref_name == 'main') && 'dev,ops' || 'none' }}
+      # Disabled for testing purposes to see if created config looks good. Uncomment when ready to deploy.
+      #auto-merge-environments: dev,ops
+      # Deploy provisioned plugin to Grafana Cloud
+      grafana-cloud-deployment-type: provisioned
+      argo-workflow-slack-channel: '#proj-profilesdrilldown-cd'
+
+      # Add the git head ref sha to the plugin version as suffix (`+abcdef`). This is required for CD builds.
+      plugin-version-suffix: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}
+
+      run-playwright: false
+      run-playwright-docker: true
+      run-playwright-with-skip-grafana-dev-image: true
+      upload-playwright-artifacts: true
+      run-playwright-with-grafana-dependency: '>=12.1.0'
+      playwright-config: e2e/config/playwright.config.ci.ts
+      playwright-docker-compose-file: docker-compose.e2e.yaml
+      playwright-report-path: 'e2e/test-reports/'

--- a/.github/workflows/plugins-pr.yml
+++ b/.github/workflows/plugins-pr.yml
@@ -1,4 +1,4 @@
-name: Plugins Platform Publish - CD
+name: (New) Plugins - Publish Branch To Dev
 run-name: Deploy ${{ inputs.branch }}
 
 on:

--- a/.github/workflows/plugins-pr.yml
+++ b/.github/workflows/plugins-pr.yml
@@ -28,6 +28,12 @@ jobs:
       branch: ${{ inputs.branch }}
       environment: dev
       # No grafana-cloud-deployment-type defined -> plugin will be published to the catalog, but not deployed to Grafana Cloud
-      # Skip tests (they are run in the main PR/CI workflow)
+
       run-playwright: false
-      run-playwright-docker: false
+      run-playwright-docker: true
+      run-playwright-with-skip-grafana-dev-image: true
+      upload-playwright-artifacts: true
+      run-playwright-with-grafana-dependency: '>=12.1.0'
+      playwright-config: e2e/config/playwright.config.ci.ts
+      playwright-docker-compose-file: docker-compose.e2e.yaml
+      playwright-report-path: 'e2e/test-reports/'

--- a/.github/workflows/plugins-pr.yml
+++ b/.github/workflows/plugins-pr.yml
@@ -1,19 +1,12 @@
 name: Plugins Platform Publish - CD
-run-name: Deploy ${{ inputs.branch }} to ${{ inputs.environment }} by @${{ github.actor }}
+run-name: Deploy ${{ inputs.branch }}
 
 on:
   workflow_dispatch:
     inputs:
       branch:
         description: Branch to publish from. Can be used to deploy PRs to dev
-        default: main
-      environment:
-        description: Environment to publish to
         required: true
-        type: choice
-        options:
-          - 'dev'
-          - 'ops'
       docs-only:
         description: Only publish docs, do not publish the plugin
         default: false
@@ -32,25 +25,7 @@ jobs:
       id-token: write
       attestations: write
     with:
-      # Checkout/build PR or main branch, depending on event
-      branch: ${{ github.event_name == 'push' && github.ref_name || github.ref }}
+      branch: ${{ inputs.branch }}
+      environment: ops
+      # No grafana-cloud-deployment-type defined -> plugin will be published to the catalog, but not deployed to Grafana Cloud
 
-      # When pushing to "main", publish and deploy to "dev" (CD). For PRs, skip publishing and deploying (run CI only)
-      environment: ${{ (github.event_name == 'push' && github.ref_name == 'main') && 'dev,ops' || 'none' }}
-      # Disabled for testing purposes to see if created config looks good. Uncomment when ready to deploy.
-      #auto-merge-environments: dev,ops
-      # Deploy provisioned plugin to Grafana Cloud
-      grafana-cloud-deployment-type: provisioned
-      argo-workflow-slack-channel: '#proj-profilesdrilldown-cd'
-
-      # Add the git head ref sha to the plugin version as suffix (`+abcdef`). This is required for CD builds.
-      plugin-version-suffix: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}
-
-      run-playwright: false
-      run-playwright-docker: true
-      run-playwright-with-skip-grafana-dev-image: true
-      upload-playwright-artifacts: true
-      run-playwright-with-grafana-dependency: '>=12.1.0'
-      playwright-config: e2e/config/playwright.config.ci.ts
-      playwright-docker-compose-file: docker-compose.e2e.yaml
-      playwright-report-path: 'e2e/test-reports/'

--- a/.github/workflows/plugins-release.yml
+++ b/.github/workflows/plugins-release.yml
@@ -11,11 +11,6 @@ on:
           - patch
           - minor
           - major
-      generate-changelog:
-        description: 'Generate changelog'
-        required: false
-        type: boolean
-        default: true
 
 # No global permissions, each job defines own scope
 permissions: {}
@@ -32,11 +27,13 @@ jobs:
       - name: Version bump
         uses: grafana/plugin-ci-workflows/actions/plugins/version-bump-changelog@main
         with:
-          generate-changelog: ${{ inputs.generate-changelog }}
+          # We generate changelog in npm version command via `standard-changelog` library
+          generate-changelog: false
           version: ${{ inputs.version }}
 
   cd:
     name: CI / CD
+    needs: bump-version
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main
     # These are maximum permissions for the job and should match the permissions defined in the workflow
     permissions:
@@ -44,8 +41,6 @@ jobs:
       id-token: write
       attestations: write
     with:
-      # Checkout/build PR or main branch, depending on event
-      branch: ${{ github.event_name == 'push' && github.ref_name || github.ref }}
 
       environment: prod
       attestation: true


### PR DESCRIPTION
This will allow us to publish PRs for testing (previously done with upload label). To unlock [the full flow ](https://raintank-corp.slack.com/archives/C075BDBTX96/p1752223206316099?thread_ts=1752168379.983589&cid=C075BDBTX96)we also need https://github.com/grafana/hosted-grafana/pull/6698 merged.