### PR TITLE
fix: Update grafana/assistant

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@bufbuild/buf": "^1.50.0",
     "@bufbuild/protoc-gen-es": "^2.2.3",
     "@connectrpc/protoc-gen-connect-query": "^2.0.1",
-    "@grafana/assistant": "0.0.12",
+    "@grafana/assistant": "0.0.17",
     "@grafana/e2e-selectors": "^10.0.0",
     "@grafana/eslint-config": "^8.0.0",
     "@grafana/tsconfig": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1550,9 +1550,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/assistant@npm:0.0.12":
-  version: 0.0.12
-  resolution: "@grafana/assistant@npm:0.0.12"
+"@grafana/assistant@npm:0.0.17":
+  version: 0.0.17
+  resolution: "@grafana/assistant@npm:0.0.17"
   peerDependencies:
     "@grafana/data": ">=12.1.0"
     "@grafana/runtime": ">=12.1.0"
@@ -1560,7 +1560,7 @@ __metadata:
     "@grafana/ui": ">=12.1.0"
     react: ">=18.0.0"
     rxjs: ">=7.0.0"
-  checksum: 10/ebf714e025bc919149fc88b41bf0f9c89805285488324233149d61749a812e7c1c65934e42863f739d87f731af3d8c8ccfa783701587b03d1e6ee844a0a7e7a3
+  checksum: 10/0d10a4cb0b1dd1082157f106072b5ea164471b51e0a7ee8b70c48b6d3115d049d36783a04f0b04d6202f2eac01863fa08efd61ecf4d79febfc039966133c1c6a
   languageName: node
   linkType: hard
 
@@ -11761,7 +11761,7 @@ __metadata:
     "@connectrpc/connect-web": "npm:^2.0.1"
     "@connectrpc/protoc-gen-connect-query": "npm:^2.0.1"
     "@emotion/css": "npm:11.10.6"
-    "@grafana/assistant": "npm:0.0.12"
+    "@grafana/assistant": "npm:0.0.17"
     "@grafana/data": "npm:^12.1.0"
     "@grafana/e2e-selectors": "npm:^10.0.0"
     "@grafana/eslint-config": "npm:^8.0.0"


### PR DESCRIPTION
fixes #596 

This will include the fix for calling a function that is not available in Grafana 11.6 (https://github.com/grafana/grafana-assistant-app/pull/1239)