### PR TITLE
chore: Add missing target to plugin.json

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -65,7 +65,7 @@
       {
         "title": "Open in Grafana Profiles Drilldown",
         "description": "Try our new queryless experience for profiles",
-        "targets": ["grafana/explore/toolbar/action", "grafana/traceview/details"]
+        "targets": ["grafana/explore/toolbar/action", "grafana/traceview/details", "grafana-assistant-app/navigateToDrilldown/v1"]
       }
     ]
   }


### PR DESCRIPTION
Add missing target from https://github.com/grafana/profiles-drilldown/pull/593