### PR TITLE
fix: retain cookie expiration

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/GitHubContext.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/GitHubContext.ts
@@ -5,6 +5,7 @@ export type TGitHubContext = {
   isSessionExpired: boolean;
   isLoginInProgress: boolean;
   login: () => Promise<void>;
+  logout: () => void;
 };
 
 export const DEFAULT_GITHUB_CONTEXT: TGitHubContext = {
@@ -12,6 +13,7 @@ export const DEFAULT_GITHUB_CONTEXT: TGitHubContext = {
   isLoggedIn: false,
   isSessionExpired: false,
   login: async () => {},
+  logout: () => {},
 };
 
 export const GitHubContext = createContext(DEFAULT_GITHUB_CONTEXT);

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/GitHubContextProvider.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/GitHubContextProvider.tsx
@@ -18,7 +18,7 @@ type GitHubContextProviderProps = {
 export const nonce = generateNonce();
 
 // Keep the data source UID in session storage to reuse it if the page is refreshed
-const SESSION_DATA_SOURCE_KEY = `grafana-pyroscope-app.gitHubIntegration.dataSourceUid`;
+const LOCAL_STORAGE_GITHUB_INTEGRATION_DATASOURCE_UID = `grafana-pyroscope-app.gitHubIntegration.dataSourceUid`;
 
 export function GitHubContextProvider({ dataSourceUid, children }: GitHubContextProviderProps) {
   const vcsClient = DataSourceProxyClientBuilder.build(dataSourceUid, VcsClient);
@@ -28,14 +28,11 @@ export function GitHubContextProvider({ dataSourceUid, children }: GitHubContext
   const [sessionCookie, setSessionCookie] = useGithubSessionCookie();
   const [externalWindow, setExternalWindow] = useState<Window | null>();
 
-  // hack to prevent failures impossible to fix for the user (unless they know they have to delete the cookie)
-  // when logged in and changing data source
-  // TODO: provide a better way
   useEffect(() => {
-    const gitHubIntegrationDataSourceUid = sessionStorage.getItem(SESSION_DATA_SOURCE_KEY);
+    const gitHubIntegrationDataSourceUid = localStorage.getItem(LOCAL_STORAGE_GITHUB_INTEGRATION_DATASOURCE_UID);
     if (gitHubIntegrationDataSourceUid !== dataSourceUid) {
       setSessionCookie('');
-      sessionStorage.setItem(SESSION_DATA_SOURCE_KEY, dataSourceUid || '');
+      localStorage.setItem(LOCAL_STORAGE_GITHUB_INTEGRATION_DATASOURCE_UID, dataSourceUid || '');
     }
   }, [dataSourceUid]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/GitHubContextProvider.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/GitHubContextProvider.tsx
@@ -64,6 +64,7 @@ export function GitHubContextProvider({ dataSourceUid, children }: GitHubContext
         isLoggedIn: Boolean(sessionCookie && !sessionCookie.isUserTokenExpired()),
         isSessionExpired: Boolean(sessionCookie?.isUserTokenExpired()),
         login,
+        logout: () => setSessionCookie(''),
       }}
     >
       {children}

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/infrastructure/GitSessionCookieManager.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/infrastructure/GitSessionCookieManager.ts
@@ -60,7 +60,12 @@ class InternalGitSessionCookieManager implements GitSessionCookieManager {
       return;
     }
 
-    cookie !== undefined ? this.setCookie(`${cookie.key}=${cookie.value}`) : this.deleteCookie();
+    if (cookie === undefined) {
+      this.deleteCookie();
+    } else {
+      this.rawCookie = cookie;
+      this.sessionCookie = GitSessionCookie.decode(cookie.value);
+    }
   }
 
   private static getCookieFromJar(jar: string, name: string): Cookie | undefined {

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubRepository.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubRepository.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Button, Icon, Spinner, useStyles2 } from '@grafana/ui';
+import { Button, Icon, IconButton, Spinner, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
 import { useGitHubContext } from './GitHubContextProvider/useGitHubContext';
@@ -26,7 +26,7 @@ type GitHubRepositoryProps = {
 
 export const GitHubRepository = ({ enableIntegration, repository }: GitHubRepositoryProps) => {
   const styles = useStyles2(getStyles);
-  const { isLoginInProgress, isLoggedIn, login } = useGitHubContext();
+  const { isLoginInProgress, isLoggedIn, login, logout } = useGitHubContext();
 
   if (!enableIntegration) {
     return <>-</>;
@@ -66,6 +66,12 @@ export const GitHubRepository = ({ enableIntegration, repository }: GitHubReposi
         &nbsp;
         {repository.commitName}
       </a>
+      <IconButton
+        name="signout"
+        onClick={() => logout()}
+        aria-label="Disconnect from GitHub"
+        title="Disconnect from GitHub"
+      />
     </>
   );
 };


### PR DESCRIPTION
Fixes: #552

The main problem was in GitHubCookieManager. On initial load it attempts to restore the cookie from browser to internal state. Inadvertently it calls document.cookie = ... again but on that attempt the expiration of the cookie is lost. This is because document.cookie setter/getter are asymetric:

`document.cookie = "foo = bar; Expires XXX"`
`console.log(document.cookie)` --> "foo=bar" (expiration is not available for reading)

Setting a cookie without expiration:
`document.cookie = "foo = bar` --> will use current session as expiration 
