### PR TITLE
feat(flame graph): add a span ID selector

### DIFF
--- a/src/locales/en-US/grafana-pyroscope-app.json
+++ b/src/locales/en-US/grafana-pyroscope-app.json
@@ -676,7 +676,7 @@
     }
   },
   "span-id-filter": {
-    "label": "Span ID",
+    "exemplar-group": "Sampled span exemplars (not an exhaustive list)",
     "no-options": "No span profiles in the current time range",
     "placeholder": "Filter by span ID"
   },

--- a/src/locales/en-US/grafana-pyroscope-app.json
+++ b/src/locales/en-US/grafana-pyroscope-app.json
@@ -675,6 +675,11 @@
       }
     }
   },
+  "span-id-filter": {
+    "label": "Span ID",
+    "no-options": "No span profiles in the current time range",
+    "placeholder": "Filter by span ID"
+  },
   "timeseries": {
     "menu": {
       "add-to-dashboard": "Add to dashboard",

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/ProfileIdSelectorLabel.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/ProfileIdSelectorLabel.tsx
@@ -65,7 +65,6 @@ const activeTextColor = '#fff';
 
 const getStyles = (theme: GrafanaTheme2) => ({
   container: css`
-    margin-top: 5px;
     display: flex;
     align-items: center;
     border: 1px solid ${activeBackgroundColor};

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneExploreServiceFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneExploreServiceFlameGraph.tsx
@@ -28,7 +28,6 @@ import {
 import { SceneHeatmapMenu } from '../SceneExploreServiceHeatmap/SceneHeatmapMenu';
 import { TimeseriesReprocess } from '../SceneLabelValuesTimeseries/domain/events/TimeseriesReprocess';
 import { SceneMainServiceTimeseries } from '../SceneMainServiceTimeseries';
-import { SceneSpanIdFilter } from '../SceneSpanIdFilter/SceneSpanIdFilter';
 import { ResolutionBoostExtensionPoint } from './components/ResolutionBoostExtensionPoint';
 import { SpanHeatmapPanel } from './components/SpanHeatmapPanel';
 import { SpanProfilesToggled } from './domain/events/SpanProfilesToggled';
@@ -41,7 +40,6 @@ interface SceneExploreServiceFlameGraphState extends SceneObjectState {
   showSpanHeatmap: boolean;
   spanToggleAction: SpanExemplarToggleAction;
   heatmapMenu: SceneHeatmapMenu;
-  spanIdFilters?: SceneSpanIdFilter;
 }
 
 const HEATMAP_ITEM: GridItemData = {
@@ -99,9 +97,6 @@ export class SceneExploreServiceFlameGraph extends SceneObjectBase<SceneExploreS
         }),
       }),
       body: new SceneFlameGraph(),
-      // The span filter is only meaningful where span profiles are, which is the same feature as
-      // the heatmap its options are sourced from.
-      spanIdFilters: profilesHeatmapEnabled ? new SceneSpanIdFilter() : undefined,
     });
 
     this.profilesHeatmapEnabled = profilesHeatmapEnabled;
@@ -163,9 +158,12 @@ export class SceneExploreServiceFlameGraph extends SceneObjectBase<SceneExploreS
         });
       });
 
-    const timeRangeSub = sceneGraph.getTimeRange(this).subscribeToState(() => {
-      this.clearSpanProfileSelection();
-      this.probeSpanAvailability();
+    // The time range also emits during activation, which would wipe a span selection restored from the URL.
+    const timeRangeSub = sceneGraph.getTimeRange(this).subscribeToState((newState, prevState) => {
+      if (newState.from !== prevState.from || newState.to !== prevState.to) {
+        this.clearSpanProfileSelection();
+        this.probeSpanAvailability();
+      }
     });
 
     const dataSourceSub = sceneGraph
@@ -242,25 +240,46 @@ export class SceneExploreServiceFlameGraph extends SceneObjectBase<SceneExploreS
       return;
     }
 
+    if (openHeatmapWhenAvailable) {
+      // Optimistic, like the toggle button: a URL-restored span would flash the fallback chip during the probe.
+      this.state.body.setState({ spanHeatmapActive: true });
+    }
+
+    // null = a newer probe owns the state, leave it alone.
+    const hasSpanData = await this.fetchSpanAvailability(spanHeatmapQuery, requestId);
+    if (hasSpanData === null || !openHeatmapWhenAvailable) {
+      return;
+    }
+
+    if (hasSpanData) {
+      this.openSpanHeatmapMode();
+    } else {
+      this.state.body.setState({ spanHeatmapActive: false });
+    }
+  }
+
+  private async fetchSpanAvailability(
+    spanHeatmapQuery: NonNullable<ReturnType<typeof buildSpanHeatmapQuery>>,
+    requestId: number
+  ): Promise<boolean | null> {
     try {
       const response = await selectHeatmap(spanHeatmapQuery.dataSourceUid, spanHeatmapQuery.request);
 
       if (requestId !== this.spanAvailabilityProbeId) {
-        return;
+        return null;
       }
 
       this.primedSpanHeatmapResponse = { response, signature: spanHeatmapQuery.signature };
       const hasSpanData = hasSpanProfiles(response);
       this.state.spanToggleAction.setState({ hasSpanData });
-      if (openHeatmapWhenAvailable && hasSpanData) {
-        this.openSpanHeatmapMode();
-      }
+      return hasSpanData;
     } catch {
       if (requestId !== this.spanAvailabilityProbeId) {
-        return;
+        return null;
       }
 
       this.state.spanToggleAction.setState({ hasSpanData: undefined });
+      return false;
     }
   }
 
@@ -346,6 +365,7 @@ export class SceneExploreServiceFlameGraph extends SceneObjectBase<SceneExploreS
 
     this.state.spanToggleAction.setState({ showSpanHeatmap: true });
     this.setState({ spanHeatmap, showSpanHeatmap: true });
+    this.state.body.setState({ spanHeatmapActive: true });
     this.onShowSpanHeatmapChange?.(true);
   }
 
@@ -380,6 +400,7 @@ export class SceneExploreServiceFlameGraph extends SceneObjectBase<SceneExploreS
     this.clearSpanProfileSelection();
     this.state.spanToggleAction.setState({ showSpanHeatmap: false });
     this.setState({ showSpanHeatmap: false });
+    this.state.body.setState({ spanHeatmapActive: false });
     this.onShowSpanHeatmapChange?.(false);
     this.probeSpanAvailability();
   }
@@ -460,9 +481,6 @@ export class SceneExploreServiceFlameGraph extends SceneObjectBase<SceneExploreS
       variables: [
         sceneGraph.findByKeyAndType(this, 'serviceName', ServiceNameVariable),
         sceneGraph.findByKeyAndType(this, 'profileMetricId', ProfileMetricVariable),
-        // Sits between the profile type and the label filters: like the pickers before it, it
-        // narrows what the flame graph queries, and it is not a label filter.
-        ...(this.state.spanIdFilters ? [this.state.spanIdFilters] : []),
         sceneGraph.findByKeyAndType(this, 'filters', FiltersVariable),
       ],
       gridControls: [],

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneExploreServiceFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneExploreServiceFlameGraph.tsx
@@ -28,6 +28,7 @@ import {
 import { SceneHeatmapMenu } from '../SceneExploreServiceHeatmap/SceneHeatmapMenu';
 import { TimeseriesReprocess } from '../SceneLabelValuesTimeseries/domain/events/TimeseriesReprocess';
 import { SceneMainServiceTimeseries } from '../SceneMainServiceTimeseries';
+import { SceneSpanIdFilter } from '../SceneSpanIdFilter/SceneSpanIdFilter';
 import { ResolutionBoostExtensionPoint } from './components/ResolutionBoostExtensionPoint';
 import { SpanHeatmapPanel } from './components/SpanHeatmapPanel';
 import { SpanProfilesToggled } from './domain/events/SpanProfilesToggled';
@@ -40,6 +41,7 @@ interface SceneExploreServiceFlameGraphState extends SceneObjectState {
   showSpanHeatmap: boolean;
   spanToggleAction: SpanExemplarToggleAction;
   heatmapMenu: SceneHeatmapMenu;
+  spanIdFilters?: SceneSpanIdFilter;
 }
 
 const HEATMAP_ITEM: GridItemData = {
@@ -97,6 +99,9 @@ export class SceneExploreServiceFlameGraph extends SceneObjectBase<SceneExploreS
         }),
       }),
       body: new SceneFlameGraph(),
+      // The span filter is only meaningful where span profiles are, which is the same feature as
+      // the heatmap its options are sourced from.
+      spanIdFilters: profilesHeatmapEnabled ? new SceneSpanIdFilter() : undefined,
     });
 
     this.profilesHeatmapEnabled = profilesHeatmapEnabled;
@@ -142,7 +147,7 @@ export class SceneExploreServiceFlameGraph extends SceneObjectBase<SceneExploreS
       }
     });
 
-    // When spanSelector changes from outside (e.g. the "×" button on SpanSelectorLabel),
+    // When spanSelector changes from outside (e.g. the "×" on the span chiclet in the query builder),
     // sync the selection into the visible heatmap.
     const spanSelectorSub = sceneGraph
       .findByKeyAndType(this, 'spanSelector', SpanSelectorVariable)
@@ -455,6 +460,9 @@ export class SceneExploreServiceFlameGraph extends SceneObjectBase<SceneExploreS
       variables: [
         sceneGraph.findByKeyAndType(this, 'serviceName', ServiceNameVariable),
         sceneGraph.findByKeyAndType(this, 'profileMetricId', ProfileMetricVariable),
+        // Sits between the profile type and the label filters: like the pickers before it, it
+        // narrows what the flame graph queries, and it is not a label filter.
+        ...(this.state.spanIdFilters ? [this.state.spanIdFilters] : []),
         sceneGraph.findByKeyAndType(this, 'filters', FiltersVariable),
       ],
       gridControls: [],
@@ -463,25 +471,13 @@ export class SceneExploreServiceFlameGraph extends SceneObjectBase<SceneExploreS
 
   static Component({ model }: SceneComponentProps<SceneExploreServiceFlameGraph>) {
     const styles = useStyles2(getStyles);
-    const {
-      mainTimeseries,
-      body,
-      spanHeatmap,
-      showSpanHeatmap,
-      heatmapMenu,
-      spanToggleAction,
-    } = model.useState();
+    const { mainTimeseries, body, spanHeatmap, showSpanHeatmap, heatmapMenu, spanToggleAction } = model.useState();
     const showHeatmapPanel = model.profilesHeatmapEnabled && showSpanHeatmap && spanHeatmap;
 
     return (
       <div className={styles.flex}>
         {showHeatmapPanel ? (
-          <SpanHeatmapPanel
-            model={model}
-            spanHeatmap={spanHeatmap}
-            menu={heatmapMenu}
-            spanToggle={spanToggleAction}
-          />
+          <SpanHeatmapPanel model={model} spanHeatmap={spanHeatmap} menu={heatmapMenu} spanToggle={spanToggleAction} />
         ) : (
           // we use CSS here and Scenes Flex layout because we encountered a problem where the Flamegraph would not respect each panel width,
           // resulting in a cropped flame graph when opening the side panel

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
@@ -4,6 +4,7 @@ import { FlameGraph, Props as FlameGraphProps } from '@grafana/flamegraph';
 import { t, Trans } from '@grafana/i18n';
 import {
   SceneComponentProps,
+  sceneGraph,
   SceneObjectBase,
   SceneObjectState,
   SceneQueryRunner,
@@ -27,6 +28,7 @@ import { Unsubscribable } from 'rxjs';
 
 import { useBuildPyroscopeQuery } from '../../domain/useBuildPyroscopeQuery';
 import { useGrafanaAssistant } from '../../domain/useGrafanaAssistant';
+import { SpanSelectorVariable } from '../../domain/variables/SpanSelectorVariable';
 import { getSceneVariableValue } from '../../helpers/getSceneVariableValue';
 import { deferSceneQueryRunnerRun } from '../../infrastructure/deferSceneQueryRunnerRun';
 import { buildFlameGraphQueryRunner } from '../../infrastructure/flame-graph/buildFlameGraphQueryRunner';
@@ -79,6 +81,16 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
   onActivate() {
     let dataSubscription: Unsubscribable | undefined;
 
+    // The span can also be cleared from the toolbar filter, which sits above this scene and cannot
+    // call removeSpanSelector(), so widen the time range off the variable emptying as well.
+    const spanSelectorSubscription = sceneGraph
+      .findByKeyAndType(this, 'spanSelector', SpanSelectorVariable)
+      .subscribeToState((newState, prevState) => {
+        if (prevState.value && !newState.value) {
+          this.setState({ $timeRange: undefined });
+        }
+      });
+
     const stateSubscription = this.subscribeToState((newState, prevState) => {
       if (newState.$data === prevState.$data) {
         return;
@@ -96,6 +108,7 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
     });
 
     return () => {
+      spanSelectorSubscription.unsubscribe();
       stateSubscription.unsubscribe();
       dataSubscription?.unsubscribe();
     };

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
@@ -14,6 +14,7 @@ import { Spinner, useStyles2, useTheme2 } from '@grafana/ui';
 import { useMaxNodesFromUrl } from '@shared/domain/url-params/useMaxNodesFromUrl';
 import { useToggleSidePanel } from '@shared/domain/useToggleSidePanel';
 import {
+  getProfilesHeatmapFromOpenFeature,
   useFlagFlameGraphWithCallTree,
   useFlagMetricsFromProfiles,
 } from '@shared/infrastructure/featureFlags/featureFlags';
@@ -37,6 +38,7 @@ import { AIButton } from '../SceneAiPanel/components/AiButton/AIButton';
 import { SceneAiPanel } from '../SceneAiPanel/SceneAiPanel';
 import { useCreateRecordingRulesMenu } from '../SceneCreateMetricModal/domain/useMenuOption';
 import { SceneCreateRecordingRuleModal } from '../SceneCreateMetricModal/SceneCreateRecordingRuleModal';
+import { SceneSpanIdFilter } from '../SceneSpanIdFilter/SceneSpanIdFilter';
 import { SamplingIndicatorExtensionPoint } from './components/SamplingIndicatorExtensionPoint';
 import { SceneExportMenu } from './components/SceneExportMenu/SceneExportMenu';
 import { useGitHubIntegration } from './components/SceneFunctionDetailsPanel/domain/useGitHubIntegration';
@@ -56,6 +58,10 @@ interface SceneFlameGraphState extends SceneObjectState {
   aiPanel: SceneAiPanel;
   functionDetailsPanel: SceneFunctionDetailsPanel;
   createRecordingRuleModal: SceneCreateRecordingRuleModal;
+  /** Header span ID filter; only mounted with the `profilesHeatmap` toggle, whose exemplar API feeds its options. */
+  spanIdFilter?: SceneSpanIdFilter;
+  /** Mirrors the parent's showSpanHeatmap: the span ID filter only belongs to the heatmap experience. */
+  spanHeatmapActive?: boolean;
 }
 
 // I've tried to use a SplitLayout for the body without any success (left: flame graph, right: explain flame graph content)
@@ -73,6 +79,7 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
       aiPanel: new SceneAiPanel(),
       functionDetailsPanel: new SceneFunctionDetailsPanel(),
       createRecordingRuleModal: new SceneCreateRecordingRuleModal(),
+      spanIdFilter: getProfilesHeatmapFromOpenFeature() ? new SceneSpanIdFilter() : undefined,
     });
 
     this.addActivationHandler(this.onActivate.bind(this));
@@ -81,8 +88,7 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
   onActivate() {
     let dataSubscription: Unsubscribable | undefined;
 
-    // The span can also be cleared from the toolbar filter, which sits above this scene and cannot
-    // call removeSpanSelector(), so widen the time range off the variable emptying as well.
+    // The header filter clears the span via the removal event, so widen the time range off the variable emptying too.
     const spanSelectorSubscription = sceneGraph
       .findByKeyAndType(this, 'spanSelector', SpanSelectorVariable)
       .subscribeToState((newState, prevState) => {
@@ -218,6 +224,7 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
 
     const spanSelector = getSceneVariableValue(model, 'spanSelector');
     const profileIdSelector = getSceneVariableValue(model, 'profileIdSelector');
+    const { spanIdFilter, spanHeatmapActive } = model.useState();
     const { data, actions } = model.useSceneFlameGraph(spanSelector, profileIdSelector);
     const sidePanel = useToggleSidePanel();
     const gitHubIntegration = useGitHubIntegration(sidePanel);
@@ -272,8 +279,17 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
           isLoading={data.isLoading}
           headerActions={
             <>
-              {spanSelector && (
-                <SpanSelectorLabel spanSelector={spanSelector} removeSpanSelector={() => model.removeSpanSelector()} />
+              {spanIdFilter && spanHeatmapActive ? (
+                // The filter shows the current span and clears it via the combobox's own clear action.
+                <spanIdFilter.Component model={spanIdFilter} />
+              ) : (
+                // Outside the heatmap experience an active span (e.g. from a shared URL) only gets a removal chip.
+                spanSelector && (
+                  <SpanSelectorLabel
+                    spanSelector={spanSelector}
+                    removeSpanSelector={() => model.removeSpanSelector()}
+                  />
+                )
               )}
               {profileIdSelector && (
                 <ProfileIdSelectorLabel

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SpanSelectorLabel.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SpanSelectorLabel.tsx
@@ -61,7 +61,6 @@ const activeTextColor = '#fff';
 
 const getStyles = (theme: GrafanaTheme2) => ({
   container: css`
-    margin-top: 5px;
     display: flex;
     align-items: center;
     border: 1px solid ${activeBackgroundColor};

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/__tests__/SceneExploreServiceFlameGraph.spec.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/__tests__/SceneExploreServiceFlameGraph.spec.ts
@@ -108,6 +108,27 @@ describe('SceneExploreServiceFlameGraph', () => {
     expect(spanHeatmap.fetchHeatmapData).toHaveBeenCalledTimes(1);
   });
 
+  it('mirrors the heatmap experience into the flame graph panel so the span ID filter only shows there', () => {
+    const scene = new SceneExploreServiceFlameGraph({});
+    jest.spyOn(scene, 'getPrimedSpanHeatmapResponse').mockReturnValue(undefined);
+    jest.spyOn(scene, 'clearSpanProfileSelection').mockImplementation();
+    jest.spyOn(scene, 'probeSpanAvailability').mockImplementation();
+
+    const spanHeatmap = {
+      primeWithResponse: jest.fn(),
+      fetchHeatmapData: jest.fn(),
+      setState: jest.fn(),
+      subscribeToState: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+    };
+    scene.setState({ spanHeatmap: spanHeatmap as unknown as SceneExploreServiceHeatmap });
+
+    scene.openSpanHeatmapMode();
+    expect(scene.state.body.state.spanHeatmapActive).toBe(true);
+
+    scene.closeSpanHeatmapMode();
+    expect(scene.state.body.state.spanHeatmapActive).toBe(false);
+  });
+
   it('opens span heatmap from URL state without recreating the scene', () => {
     const scene = new SceneExploreServiceFlameGraph({});
     const probeSpanAvailability = jest.spyOn(scene, 'probeSpanAvailability').mockImplementation();

--- a/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/components/domain/usePluginHeaderToolbar.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/components/domain/usePluginHeaderToolbar.ts
@@ -2,6 +2,7 @@ import { SceneObject, SceneVariable } from '@grafana/scenes';
 import { displaySuccess } from '@shared/domain/displayStatus';
 import { reportInteraction } from '@shared/domain/reportInteraction';
 import { logger } from '@shared/infrastructure/tracking/logger';
+import type { PluginHeaderToolbarProps } from '@shared/ui/PluginHeaderToolbar';
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { PLUGIN_BASE_URL, ROUTES } from 'src/constants';
@@ -9,7 +10,6 @@ import { getSceneVariableValue } from 'src/pages/ProfilesExplorerView/helpers/ge
 
 import { ProfilesDataSourceVariable } from '../../../../domain/variables/ProfilesDataSourceVariable';
 import { ExplorationType } from '../../SceneProfilesExplorer';
-import type { PluginHeaderToolbarProps } from '@shared/ui/PluginHeaderToolbar';
 import { builsShareableUrl } from './builsShareableUrl';
 
 async function onClickShareLink() {

--- a/src/pages/ProfilesExplorerView/components/SceneSpanIdFilter/SceneSpanIdFilter.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneSpanIdFilter/SceneSpanIdFilter.tsx
@@ -17,22 +17,15 @@ import { SpanSelectorVariable } from '../../domain/variables/SpanSelectorVariabl
 import { RemoveSpanSelector } from '../SceneExploreServiceFlameGraph/domain/events/RemoveSpanSelector';
 import { fetchSpanIdOptions } from './domain/fetchSpanIdOptions';
 
-const LABEL_DEFAULT = 'Span ID';
-
 interface SceneSpanIdFilterState extends SceneObjectState {
-  // The toolbar keys, labels and test-ids its controls off `name` and `label`, like a scene variable.
-  name: string;
-  label: string;
-  // Mirrored from the spanSelector variable: the chip, the heatmap and this control all write it, and
-  // owning a copy is what re-renders the input when one of the others clears it.
+  // Mirrored from the spanSelector variable so writes from the heatmap or exemplar table re-render the input.
   spanId: string | null;
   options: Array<ComboboxOption<string>>;
   isLoading: boolean;
 }
 
 /**
- * Toolbar span ID filter: reads and writes the same `spanSelector` variable as the panel-header chip,
- * but is reachable without first finding a span on the heatmap (#1053).
+ * Flame graph header span ID filter (#1053); lives in the panel header because it scopes only the flame graph.
  */
 export class SceneSpanIdFilter extends SceneObjectBase<SceneSpanIdFilterState> {
   private fetchRequestId = 0;
@@ -40,8 +33,6 @@ export class SceneSpanIdFilter extends SceneObjectBase<SceneSpanIdFilterState> {
   constructor() {
     super({
       key: 'spanIdFilter',
-      name: 'spanId',
-      label: LABEL_DEFAULT,
       spanId: null,
       options: [],
       isLoading: false,
@@ -51,9 +42,6 @@ export class SceneSpanIdFilter extends SceneObjectBase<SceneSpanIdFilterState> {
   }
 
   onActivate() {
-    // Translated here rather than in the constructor, like the sibling variables do.
-    this.setState({ label: t('span-id-filter.label', LABEL_DEFAULT) });
-
     // Anything can clear the span — the panel-header chip, the heatmap, a service or profile type
     // change. Mirror the variable into our own state so every one of those re-renders the input.
     const spanSelector = sceneGraph.findByKeyAndType(this, 'spanSelector', SpanSelectorVariable);
@@ -151,12 +139,14 @@ export class SceneSpanIdFilter extends SceneObjectBase<SceneSpanIdFilterState> {
   static Component = ({ model }: SceneComponentProps<SceneSpanIdFilter>) => {
     const { options, isLoading, spanId } = model.useState();
 
-    // Always rendered, like the pickers beside it: a control that appears and disappears with the
-    // service would shift the row. With no span profiles the dropdown says so instead.
+    // Hide the input until there is a span to show or options to pick — "no options" noise otherwise.
+    if (!spanId && options.length === 0) {
+      return null;
+    }
+
     return (
       <Combobox
-        // Combobox keeps the text it displays in internal state seeded at mount, so remount it on
-        // every value change to keep the input from showing a span that was cleared elsewhere.
+        // Remount on value change: Combobox seeds its display text at mount.
         key={spanId ?? 'empty'}
         id="span-id-filter"
         data-testid="span-id-filter"

--- a/src/pages/ProfilesExplorerView/components/SceneSpanIdFilter/SceneSpanIdFilter.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneSpanIdFilter/SceneSpanIdFilter.tsx
@@ -1,0 +1,176 @@
+import { t } from '@grafana/i18n';
+import {
+  AdHocFiltersVariable,
+  SceneComponentProps,
+  sceneGraph,
+  SceneObjectBase,
+  SceneObjectState,
+} from '@grafana/scenes';
+import { Combobox, ComboboxOption } from '@grafana/ui';
+import { reportInteraction } from '@shared/domain/reportInteraction';
+import React from 'react';
+
+import { ProfileMetricVariable } from '../../domain/variables/ProfileMetricVariable';
+import { ProfilesDataSourceVariable } from '../../domain/variables/ProfilesDataSourceVariable';
+import { ServiceNameVariable } from '../../domain/variables/ServiceNameVariable/ServiceNameVariable';
+import { SpanSelectorVariable } from '../../domain/variables/SpanSelectorVariable';
+import { RemoveSpanSelector } from '../SceneExploreServiceFlameGraph/domain/events/RemoveSpanSelector';
+import { fetchSpanIdOptions } from './domain/fetchSpanIdOptions';
+
+const LABEL_DEFAULT = 'Span ID';
+
+interface SceneSpanIdFilterState extends SceneObjectState {
+  // The toolbar keys, labels and test-ids its controls off `name` and `label`, like a scene variable.
+  name: string;
+  label: string;
+  // Mirrored from the spanSelector variable: the chip, the heatmap and this control all write it, and
+  // owning a copy is what re-renders the input when one of the others clears it.
+  spanId: string | null;
+  options: Array<ComboboxOption<string>>;
+  isLoading: boolean;
+}
+
+/**
+ * Toolbar span ID filter: reads and writes the same `spanSelector` variable as the panel-header chip,
+ * but is reachable without first finding a span on the heatmap (#1053).
+ */
+export class SceneSpanIdFilter extends SceneObjectBase<SceneSpanIdFilterState> {
+  private fetchRequestId = 0;
+
+  constructor() {
+    super({
+      key: 'spanIdFilter',
+      name: 'spanId',
+      label: LABEL_DEFAULT,
+      spanId: null,
+      options: [],
+      isLoading: false,
+    });
+
+    this.addActivationHandler(this.onActivate.bind(this));
+  }
+
+  onActivate() {
+    // Translated here rather than in the constructor, like the sibling variables do.
+    this.setState({ label: t('span-id-filter.label', LABEL_DEFAULT) });
+
+    // Anything can clear the span — the panel-header chip, the heatmap, a service or profile type
+    // change. Mirror the variable into our own state so every one of those re-renders the input.
+    const spanSelector = sceneGraph.findByKeyAndType(this, 'spanSelector', SpanSelectorVariable);
+
+    this.setState({ spanId: (spanSelector.state.value as string) || null });
+
+    const spanSelectorSub = spanSelector.subscribeToState((newState, prevState) => {
+      if (newState.value !== prevState.value) {
+        this.setState({ spanId: (newState.value as string) || null });
+      }
+    });
+
+    // The set of span IDs is scoped by everything that scopes the profile query, so refetch when
+    // any of it changes.
+    const timeRangeSub = sceneGraph.getTimeRange(this).subscribeToState(() => {
+      this.fetchOptions();
+    });
+
+    const dataSourceSub = sceneGraph
+      .findByKeyAndType(this, 'dataSource', ProfilesDataSourceVariable)
+      .subscribeToState((newState, prevState) => {
+        if (newState.value !== prevState.value) {
+          this.fetchOptions();
+        }
+      });
+
+    const serviceNameSub = sceneGraph
+      .findByKeyAndType(this, 'serviceName', ServiceNameVariable)
+      .subscribeToState((newState, prevState) => {
+        if (newState.value !== prevState.value) {
+          this.fetchOptions();
+        }
+      });
+
+    const profileMetricSub = sceneGraph
+      .findByKeyAndType(this, 'profileMetricId', ProfileMetricVariable)
+      .subscribeToState((newState, prevState) => {
+        if (newState.value !== prevState.value) {
+          this.fetchOptions();
+        }
+      });
+
+    // Looked up by name and typed as the base AdHocFiltersVariable rather than the app's subclass:
+    // importing that subclass drags SavedSearches, and through it the whole explorer, in here.
+    const filtersVariable = sceneGraph.lookupVariable('filters', this) as AdHocFiltersVariable | undefined;
+    const filtersSub = filtersVariable?.subscribeToState((newState, prevState) => {
+      if (JSON.stringify(newState.filters) !== JSON.stringify(prevState.filters)) {
+        this.fetchOptions();
+      }
+    });
+
+    this.fetchOptions();
+
+    return () => {
+      this.fetchRequestId++;
+      spanSelectorSub.unsubscribe();
+      timeRangeSub.unsubscribe();
+      dataSourceSub.unsubscribe();
+      serviceNameSub.unsubscribe();
+      profileMetricSub.unsubscribe();
+      filtersSub?.unsubscribe();
+    };
+  }
+
+  async fetchOptions() {
+    const requestId = ++this.fetchRequestId;
+
+    this.setState({ isLoading: true });
+
+    try {
+      const options = await fetchSpanIdOptions(this);
+
+      if (requestId === this.fetchRequestId) {
+        this.setState({ options, isLoading: false });
+      }
+    } catch {
+      // A service with no span profiles is the common case, not an error worth surfacing: the
+      // dropdown just has nothing to offer.
+      if (requestId === this.fetchRequestId) {
+        this.setState({ options: [], isLoading: false });
+      }
+    }
+  }
+
+  onChange = (option: ComboboxOption<string> | null) => {
+    if (!option?.value) {
+      this.publishEvent(new RemoveSpanSelector({}), true);
+      return;
+    }
+
+    reportInteraction('g_pyroscope_app_span_id_filter_changed', { source: 'dropdown' });
+    sceneGraph.findByKeyAndType(this, 'spanSelector', SpanSelectorVariable).changeValueTo(option.value);
+  };
+
+  static Component = ({ model }: SceneComponentProps<SceneSpanIdFilter>) => {
+    const { options, isLoading, spanId } = model.useState();
+
+    // Always rendered, like the pickers beside it: a control that appears and disappears with the
+    // service would shift the row. With no span profiles the dropdown says so instead.
+    return (
+      <Combobox
+        // Combobox keeps the text it displays in internal state seeded at mount, so remount it on
+        // every value change to keep the input from showing a span that was cleared elsewhere.
+        key={spanId ?? 'empty'}
+        id="span-id-filter"
+        data-testid="span-id-filter"
+        placeholder={t('span-id-filter.placeholder', 'Filter by span ID')}
+        noOptionsMessage={t('span-id-filter.no-options', 'No span profiles in the current time range')}
+        options={options}
+        loading={isLoading}
+        value={spanId}
+        isClearable
+        createCustomValue
+        // Matches the profile type picker beside it (ProfileMetricVariable).
+        width={24}
+        onChange={model.onChange}
+      />
+    );
+  };
+}

--- a/src/pages/ProfilesExplorerView/components/SceneSpanIdFilter/__tests__/SceneSpanIdFilter.spec.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneSpanIdFilter/__tests__/SceneSpanIdFilter.spec.tsx
@@ -1,0 +1,114 @@
+import { SceneObjectBase, SceneObjectState, SceneVariableSet } from '@grafana/scenes';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { SpanSelectorVariable } from '../../../domain/variables/SpanSelectorVariable';
+import { RemoveSpanSelector } from '../../SceneExploreServiceFlameGraph/domain/events/RemoveSpanSelector';
+import { SceneSpanIdFilter } from '../SceneSpanIdFilter';
+
+// Fetching options pulls in the heatmap scene, which reaches TransformStream (absent in jsdom). The
+// fetching is covered by domain/__tests__/fetchSpanIdOptions.spec.ts.
+jest.mock('../domain/fetchSpanIdOptions', () => ({
+  fetchSpanIdOptions: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('@shared/domain/reportInteraction', () => ({
+  reportInteraction: jest.fn(),
+}));
+
+const { reportInteraction } = jest.requireMock('@shared/domain/reportInteraction');
+
+// Combobox measures option text on a canvas, which jsdom does not implement. Plain assignment to the
+// prototype does not stick, hence defineProperty.
+beforeAll(() => {
+  Object.defineProperty(Object.getPrototypeOf(document.createElement('canvas')), 'getContext', {
+    configurable: true,
+    writable: true,
+    value: () => ({ measureText: () => ({ width: 100 }), font: '' }),
+  });
+});
+
+class TestScene extends SceneObjectBase<SceneObjectState & { spanIdFilters: SceneSpanIdFilter }> {}
+
+// Not activated: activating a SceneVariableSet validates each variable against its (empty) options
+// and would wipe the values, and activating SceneSpanIdFilter would fire a real heatmap query.
+function buildScene(values: { span?: string } = {}) {
+  const spanIdFilters = new SceneSpanIdFilter();
+  const spanSelector = new SpanSelectorVariable();
+
+  spanSelector.setState({ value: values.span });
+  // onActivate mirrors the variable into this state for real; the scene here is not activated.
+  spanIdFilters.setState({ spanId: values.span ?? null });
+
+  const scene = new TestScene({
+    spanIdFilters,
+    $variables: new SceneVariableSet({ variables: [spanSelector] }),
+  });
+
+  return { scene, spanIdFilters };
+}
+
+describe('SceneSpanIdFilter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('span ID', () => {
+    it('writes the picked span into the spanSelector variable', () => {
+      const { scene, spanIdFilters } = buildScene();
+
+      spanIdFilters.onChange({ value: 'span-a', label: 'span-a' });
+
+      expect(scene.state.$variables!.getByName('spanSelector')!.getValue()).toBe('span-a');
+      expect(reportInteraction).toHaveBeenCalledWith('g_pyroscope_app_span_id_filter_changed', {
+        source: 'dropdown',
+      });
+    });
+
+    it('publishes a removal when the filter is cleared', () => {
+      const { scene, spanIdFilters } = buildScene({ span: 'span-a' });
+      const published: string[] = [];
+      scene.subscribeToEvent(RemoveSpanSelector, () => published.push('span'));
+
+      spanIdFilters.onChange(null);
+
+      expect(published).toEqual(['span']);
+    });
+  });
+
+  describe('visibility', () => {
+    it('renders even when there is nothing to pick and nothing selected', () => {
+      const { spanIdFilters } = buildScene();
+
+      render(<SceneSpanIdFilter.Component model={spanIdFilters} />);
+
+      expect(screen.getByTestId('span-id-filter')).toBeInTheDocument();
+    });
+
+    it('renders while the options are still loading', () => {
+      const { spanIdFilters } = buildScene();
+      spanIdFilters.setState({ isLoading: true });
+
+      render(<SceneSpanIdFilter.Component model={spanIdFilters} />);
+
+      expect(screen.getByTestId('span-id-filter')).toBeInTheDocument();
+    });
+
+    it('renders when a span is selected, so an active filter stays clearable', () => {
+      const { spanIdFilters } = buildScene({ span: 'span-a' });
+
+      render(<SceneSpanIdFilter.Component model={spanIdFilters} />);
+
+      expect(screen.getByTestId('span-id-filter')).toHaveValue('span-a');
+    });
+
+    it('renders when there are options to pick from', () => {
+      const { spanIdFilters } = buildScene();
+      spanIdFilters.setState({ options: [{ value: 'span-a', label: 'span-a' }] });
+
+      render(<SceneSpanIdFilter.Component model={spanIdFilters} />);
+
+      expect(screen.getByTestId('span-id-filter')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/ProfilesExplorerView/components/SceneSpanIdFilter/__tests__/SceneSpanIdFilter.spec.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneSpanIdFilter/__tests__/SceneSpanIdFilter.spec.tsx
@@ -77,21 +77,21 @@ describe('SceneSpanIdFilter', () => {
   });
 
   describe('visibility', () => {
-    it('renders even when there is nothing to pick and nothing selected', () => {
+    it('hides when there is nothing to pick and nothing selected', () => {
       const { spanIdFilters } = buildScene();
 
       render(<SceneSpanIdFilter.Component model={spanIdFilters} />);
 
-      expect(screen.getByTestId('span-id-filter')).toBeInTheDocument();
+      expect(screen.queryByTestId('span-id-filter')).not.toBeInTheDocument();
     });
 
-    it('renders while the options are still loading', () => {
+    it('stays hidden while the first options fetch is still loading', () => {
       const { spanIdFilters } = buildScene();
       spanIdFilters.setState({ isLoading: true });
 
       render(<SceneSpanIdFilter.Component model={spanIdFilters} />);
 
-      expect(screen.getByTestId('span-id-filter')).toBeInTheDocument();
+      expect(screen.queryByTestId('span-id-filter')).not.toBeInTheDocument();
     });
 
     it('renders when a span is selected, so an active filter stays clearable', () => {

--- a/src/pages/ProfilesExplorerView/components/SceneSpanIdFilter/domain/__tests__/fetchSpanIdOptions.spec.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneSpanIdFilter/domain/__tests__/fetchSpanIdOptions.spec.ts
@@ -1,0 +1,101 @@
+import { SceneObject } from '@grafana/scenes';
+
+import { fetchSpanIdOptions } from '../fetchSpanIdOptions';
+
+jest.mock('../../../SceneExploreServiceHeatmap/SceneExploreServiceHeatmap', () => ({
+  buildSpanHeatmapQuery: jest.fn(),
+}));
+
+jest.mock('../../../SceneExploreServiceHeatmap/infrastructure/HeatmapApiClient', () => ({
+  selectHeatmap: jest.fn(),
+}));
+
+const { buildSpanHeatmapQuery } = jest.requireMock('../../../SceneExploreServiceHeatmap/SceneExploreServiceHeatmap');
+const { selectHeatmap } = jest.requireMock('../../../SceneExploreServiceHeatmap/infrastructure/HeatmapApiClient');
+
+const scene = {} as SceneObject;
+
+/** Shapes a SelectHeatmapResponse with the given exemplars, ordered by descending value. */
+function buildResponse(exemplars: Array<{ spanId?: string; profileId?: string; value: number; spanName?: string }>) {
+  return {
+    series: [
+      {
+        labels: [],
+        slots: [
+          {
+            exemplars: exemplars.map(({ spanId, profileId, value, spanName }) => ({
+              spanId,
+              profileId: profileId ?? 'profile-1',
+              timestamp: 1_000,
+              value,
+              labels: spanName ? [{ name: 'span_name', value: spanName }] : [],
+            })),
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe('fetchSpanIdOptions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    buildSpanHeatmapQuery.mockReturnValue({ dataSourceUid: 'ds-uid', request: {}, profileTypeId: 'x', signature: 's' });
+  });
+
+  it('returns one option per span, labelled by ID and described by span name', async () => {
+    selectHeatmap.mockResolvedValue(
+      buildResponse([
+        { spanId: 'span-a', value: 30, spanName: 'GET /' },
+        { spanId: 'span-b', value: 20 },
+      ])
+    );
+
+    await expect(fetchSpanIdOptions(scene)).resolves.toEqual([
+      { value: 'span-a', label: 'span-a', description: 'GET /' },
+      { value: 'span-b', label: 'span-b', description: undefined },
+    ]);
+  });
+
+  it('keeps the heaviest occurrence of a span that appears more than once', async () => {
+    selectHeatmap.mockResolvedValue(
+      buildResponse([
+        { spanId: 'span-a', value: 30, spanName: 'heaviest' },
+        { spanId: 'span-a', value: 10, spanName: 'lighter' },
+      ])
+    );
+
+    const options = await fetchSpanIdOptions(scene);
+
+    expect(options).toHaveLength(1);
+    expect(options[0].description).toBe('heaviest');
+  });
+
+  it('skips exemplars that have no span ID', async () => {
+    selectHeatmap.mockResolvedValue(
+      buildResponse([
+        { profileId: 'profile-only', value: 30 },
+        { spanId: 'span-a', value: 20 },
+      ])
+    );
+
+    await expect(fetchSpanIdOptions(scene)).resolves.toEqual([
+      { value: 'span-a', label: 'span-a', description: undefined },
+    ]);
+  });
+
+  it('caps the number of options', async () => {
+    selectHeatmap.mockResolvedValue(
+      buildResponse(Array.from({ length: 10 }, (_, index) => ({ spanId: `span-${index}`, value: 10 - index })))
+    );
+
+    await expect(fetchSpanIdOptions(scene, 3)).resolves.toHaveLength(3);
+  });
+
+  it('does not query when the scene has no complete profile query yet', async () => {
+    buildSpanHeatmapQuery.mockReturnValue(undefined);
+
+    await expect(fetchSpanIdOptions(scene)).resolves.toEqual([]);
+    expect(selectHeatmap).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/ProfilesExplorerView/components/SceneSpanIdFilter/domain/__tests__/fetchSpanIdOptions.spec.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneSpanIdFilter/domain/__tests__/fetchSpanIdOptions.spec.ts
@@ -52,8 +52,9 @@ describe('fetchSpanIdOptions', () => {
     );
 
     await expect(fetchSpanIdOptions(scene)).resolves.toEqual([
-      { value: 'span-a', label: 'span-a', description: 'GET /' },
-      { value: 'span-b', label: 'span-b', description: undefined },
+      // Grouped so the dropdown presents exemplars as a sample rather than an exhaustive list.
+      { value: 'span-a', label: 'span-a', description: 'GET /', group: expect.any(String) },
+      { value: 'span-b', label: 'span-b', description: undefined, group: expect.any(String) },
     ]);
   });
 
@@ -80,7 +81,7 @@ describe('fetchSpanIdOptions', () => {
     );
 
     await expect(fetchSpanIdOptions(scene)).resolves.toEqual([
-      { value: 'span-a', label: 'span-a', description: undefined },
+      { value: 'span-a', label: 'span-a', description: undefined, group: expect.any(String) },
     ]);
   });
 

--- a/src/pages/ProfilesExplorerView/components/SceneSpanIdFilter/domain/fetchSpanIdOptions.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneSpanIdFilter/domain/fetchSpanIdOptions.ts
@@ -1,0 +1,41 @@
+import { SceneObject } from '@grafana/scenes';
+import { ComboboxOption } from '@grafana/ui';
+
+import { extractExemplarRows } from '../../SceneExploreServiceHeatmap/infrastructure/buildHeatmapDataFrames';
+import { selectHeatmap } from '../../SceneExploreServiceHeatmap/infrastructure/HeatmapApiClient';
+import { buildSpanHeatmapQuery } from '../../SceneExploreServiceHeatmap/SceneExploreServiceHeatmap';
+
+/**
+ * Span IDs for the current scene, from the same exemplar query the span heatmap runs. Exemplars arrive
+ * heaviest first and can repeat, so duplicates are dropped keeping the first occurrence.
+ */
+export async function fetchSpanIdOptions(scene: SceneObject, limit = 100): Promise<Array<ComboboxOption<string>>> {
+  const query = buildSpanHeatmapQuery(scene);
+
+  if (!query) {
+    return [];
+  }
+
+  const response = await selectHeatmap(query.dataSourceUid, query.request);
+  const options: Array<ComboboxOption<string>> = [];
+  const seen = new Set<string>();
+
+  for (const row of extractExemplarRows(response)) {
+    if (!row.spanId || seen.has(row.spanId)) {
+      continue;
+    }
+
+    seen.add(row.spanId);
+    options.push({
+      value: row.spanId,
+      label: row.spanId,
+      description: row.spanName,
+    });
+
+    if (options.length >= limit) {
+      break;
+    }
+  }
+
+  return options;
+}

--- a/src/pages/ProfilesExplorerView/components/SceneSpanIdFilter/domain/fetchSpanIdOptions.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneSpanIdFilter/domain/fetchSpanIdOptions.ts
@@ -1,3 +1,4 @@
+import { t } from '@grafana/i18n';
 import { SceneObject } from '@grafana/scenes';
 import { ComboboxOption } from '@grafana/ui';
 
@@ -19,6 +20,8 @@ export async function fetchSpanIdOptions(scene: SceneObject, limit = 100): Promi
   const response = await selectHeatmap(query.dataSourceUid, query.request);
   const options: Array<ComboboxOption<string>> = [];
   const seen = new Set<string>();
+  // Group the options as a sample: exemplars are not an exhaustive span list.
+  const group = t('span-id-filter.exemplar-group', 'Sampled span exemplars (not an exhaustive list)');
 
   for (const row of extractExemplarRows(response)) {
     if (!row.spanId || seen.has(row.spanId)) {
@@ -30,6 +33,7 @@ export async function fetchSpanIdOptions(scene: SceneObject, limit = 100): Promi
       value: row.spanId,
       label: row.spanId,
       description: row.spanName,
+      group,
     });
 
     if (options.length >= limit) {

--- a/src/pages/ProfilesExplorerView/domain/variables/SpanSelectorVariable.tsx
+++ b/src/pages/ProfilesExplorerView/domain/variables/SpanSelectorVariable.tsx
@@ -9,7 +9,8 @@ export class SpanSelectorVariable extends CustomVariable {
       key: 'spanSelector',
       name: 'spanSelector',
       label: SPAN_SELECTOR_LABEL_DEFAULT,
-      value: undefined,
+      // '' not undefined, which the URL sync stringifies into a truthy "undefined".
+      value: '',
     });
 
     this.addActivationHandler(this.onActivate.bind(this));
@@ -20,6 +21,6 @@ export class SpanSelectorVariable extends CustomVariable {
   }
 
   reset() {
-    this.setState({ value: undefined });
+    this.setState({ value: '' });
   }
 }

--- a/src/shared/components/QueryBuilder/QueryBuilder.tsx
+++ b/src/shared/components/QueryBuilder/QueryBuilder.tsx
@@ -36,10 +36,6 @@ const getStyles = () => ({
     align-self: flex-start;
     flex-grow: 1;
   `,
-  executeButton: css`
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-  `,
 });
 
 export type QueryBuilderProps = {
@@ -136,7 +132,6 @@ function QueryBuilderComponent(props: QueryBuilderProps) {
                 ? t('query-builder.execute-tooltip', 'Execute new query')
                 : t('query-builder.nothing-to-execute-tooltip', 'Nothing to execute, all filters applied')
             }
-            className={styles.executeButton}
             disabled={isQueryUpToDate}
           >
             <Trans i18nKey="query-builder.execute">Execute</Trans>

--- a/src/shared/components/QueryBuilder/ui/selects/DisabledSelect.tsx
+++ b/src/shared/components/QueryBuilder/ui/selects/DisabledSelect.tsx
@@ -1,13 +1,10 @@
-import { Select, useStyles2 } from '@grafana/ui';
+import { Select } from '@grafana/ui';
 import React from 'react';
 
 import { getMessages } from '../constants';
-import { getStyles } from './SingleSelect';
 
 const noOp = () => {};
 
 export function DisabledSelect() {
-  const styles = useStyles2(getStyles);
-
-  return <Select disabled className={styles.select} placeholder={getMessages().FILTER_ADD} onChange={noOp} />;
+  return <Select disabled placeholder={getMessages().FILTER_ADD} onChange={noOp} />;
 }

--- a/src/shared/components/QueryBuilder/ui/selects/SingleSelect.tsx
+++ b/src/shared/components/QueryBuilder/ui/selects/SingleSelect.tsx
@@ -1,17 +1,9 @@
-import { css } from '@emotion/css';
 import { SelectableValue } from '@grafana/data';
-import { Select, useStyles2 } from '@grafana/ui';
+import { Select } from '@grafana/ui';
 import React, { useEffect, useState } from 'react';
 
 import { getMessages } from '../constants';
 import { SingleEditionInput } from '../inputs/SingleEditionInput';
-
-export const getStyles = () => ({
-  select: css`
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-  `,
-});
 
 type SingleSelectProps = {
   suggestions: any;
@@ -44,7 +36,6 @@ function useEnsureIsOpenHack(isVisible: boolean) {
 }
 
 export function SingleSelect({ suggestions, onFocus, onChange, onKeyDown, onCloseMenu }: SingleSelectProps) {
-  const styles = useStyles2(getStyles);
   const isOpen = useEnsureIsOpenHack(suggestions.isVisible);
 
   if (suggestions.allowCustomValue) {
@@ -60,7 +51,6 @@ export function SingleSelect({ suggestions, onFocus, onChange, onKeyDown, onClos
 
   return (
     <Select
-      className={styles.select}
       placeholder={suggestions.placeholder}
       loadingMessage={getMessages().LOADING}
       closeMenuOnSelect={false}

--- a/src/shared/domain/reportInteraction.ts
+++ b/src/shared/domain/reportInteraction.ts
@@ -56,6 +56,9 @@ export type Interactions = {
   g_pyroscope_app_span_trace_opened: {
     source: 'trace-id' | 'action';
   };
+  g_pyroscope_app_span_id_filter_changed: {
+    source: 'dropdown';
+  };
   g_pyroscope_app_export_profile: {
     format: 'png' | 'json' | 'pprof' | 'flamegraph.com';
   };

--- a/src/shared/ui/Panel/GrafanaPanelBox/GrafanaPanelBox.tsx
+++ b/src/shared/ui/Panel/GrafanaPanelBox/GrafanaPanelBox.tsx
@@ -348,7 +348,8 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     rightActions: css({
       display: 'flex',
-      padding: theme.spacing(0, padding),
+      alignItems: 'center',
+      padding: theme.spacing(1, padding, 0, padding),
       gap: theme.spacing(1),
     }),
     rightAligned: css({

--- a/src/shared/ui/PluginHeaderToolbar.tsx
+++ b/src/shared/ui/PluginHeaderToolbar.tsx
@@ -6,15 +6,15 @@ import { ButtonGroup, Dropdown, ErrorBoundary, Field, Icon, Menu, ToolbarButton,
 import { SaveSearchButton } from '@shared/components/SavedSearches/SaveSearchButton';
 import { useFlagMetricsFromProfiles } from '@shared/infrastructure/featureFlags/featureFlags';
 import { useFetchPluginSettings } from '@shared/infrastructure/settings/useFetchPluginSettings';
-import { PluginInfo } from './PluginInfo';
 import React from 'react';
-
+import { usePluginHeaderToolbar } from 'src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/components/domain/usePluginHeaderToolbar';
+import { ExplorationTypeSelector } from 'src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/components/ui/ExplorationTypeSelector';
 import {
   SceneProfilesExplorer,
   SceneProfilesExplorerState,
 } from 'src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/SceneProfilesExplorer';
-import { usePluginHeaderToolbar } from 'src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/components/domain/usePluginHeaderToolbar';
-import { ExplorationTypeSelector } from 'src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/components/ui/ExplorationTypeSelector';
+
+import { PluginInfo } from './PluginInfo';
 
 export type PluginHeaderToolbarProps = {
   model: SceneProfilesExplorer;
@@ -235,13 +235,17 @@ const getStyles = (theme: GrafanaTheme2, chromeHeaderHeight: number, isEmbedded:
       width: ${theme.spacing(32)};
     }
 
+    // The label filters fill the row, but the floor keeps them from compressing to a few characters
+    // on narrow viewports — they wrap onto their own line instead.
     &.filters {
       flex: 1 1 0;
+      min-width: ${theme.spacing(40)};
     }
 
     &.filtersAllServices {
       // Set to 2 to add priority over quick-filter.
       flex: 2 1 0;
+      min-width: ${theme.spacing(40)};
     }
 
     &.compare-presets {


### PR DESCRIPTION
### ✨ Description

Issue: #1053 (Improve span selector placement in profiles exploration)

Updated the Span Id to use combobox and show span ID with the caveat that it is not an exhaustive list. If people think this treatment of the Span ID is better I can update the Profile ID too.
<img width="1617" height="632" alt="Screenshot 2026-08-10 at 1 24 00 PM" src="https://github.com/user-attachments/assets/59b33c0c-386b-4d9e-9983-cf7b2378ee0a" />



https://github.com/user-attachments/assets/6a584798-9a10-4f3c-8a1f-6dc8cc636727

