### PR TITLE
chore(faro): duplicate rudderstack events as faro events and enhance instrumentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@emotion/css": "11.10.6",
     "@grafana/assistant": "0.1.25",
     "@grafana/data": "13.1.0",
+    "@grafana/faro-core": "2.7.1",
     "@grafana/faro-web-sdk": "2.7.1",
     "@grafana/flamegraph": "13.1.0",
     "@grafana/i18n": "13.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       '@grafana/data':
         specifier: 13.1.0
         version: 13.1.0(eslint@9.39.4(jiti@2.7.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.6.2)
+      '@grafana/faro-core':
+        specifier: 2.7.1
+        version: 2.7.1
       '@grafana/faro-web-sdk':
         specifier: 2.7.1
         version: 2.7.1
@@ -4986,6 +4989,7 @@ packages:
 
   react-grid-layout@1.5.3:
     resolution: {integrity: sha512-KaG6IbjD6fYhagUtIvOzhftXG+ViKZjCjADe86X1KHl7C/dsBN2z0mi14nbvZKTkp0RKiil9RPcJBgq3LnoA8g==}
+    deprecated: 'Ships stray files that were never in the repo: an ip_fetcher binary and its curl-sample source (1.5.0-1.5.3), plus a yarn-error.log containing local paths (1.5.3). Upgrade to 1.5.4, which is byte-identical apart from removing them. See https://github.com/react-grid-layout/react-grid-layout/issues/2269'
     peerDependencies:
       react: '>= 16.3.0'
       react-dom: '>= 16.3.0'

--- a/src/pages/ProfilesExplorerView/components/SceneCreateMetricModal/SceneCreateRecordingRuleModal.test.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneCreateMetricModal/SceneCreateRecordingRuleModal.test.tsx
@@ -14,6 +14,10 @@ jest.mock('./domain/useCreateRecordingRule', () => ({
   useCreateRecordingRule: () => ({ actions: { save: mockSave } }),
 }));
 
+jest.mock('@shared/domain/reportInteraction', () => ({
+  reportInteraction: jest.fn(),
+}));
+
 jest.mock('@shared/infrastructure/labels/labelsRepository', () => ({
   labelsRepository: { listLabels: () => Promise.resolve([{ value: 'service_repository' }]) },
 }));

--- a/src/pages/ProfilesExplorerView/components/SceneCreateMetricModal/SceneCreateRecordingRuleModal.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneCreateMetricModal/SceneCreateRecordingRuleModal.tsx
@@ -3,6 +3,7 @@ import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { Button, Divider, Field, Input, Modal, MultiSelect, Text, useStyles2 } from '@grafana/ui';
+import { reportInteraction } from '@shared/domain/reportInteraction';
 import { labelsRepository } from '@shared/infrastructure/labels/labelsRepository';
 import { getProfileMetric, ProfileMetricId } from '@shared/infrastructure/profile-metrics/getProfileMetric';
 import { RecordingRuleViewModel } from '@shared/types/RecordingRuleViewModel';
@@ -113,6 +114,7 @@ export class SceneCreateRecordingRuleModal extends SceneObjectBase<SceneCreateRe
         readonly: false,
       };
       await actions.save(rule);
+      reportInteraction('g_pyroscope_app_recording_rule_created');
       onCreated();
     };
 

--- a/src/pages/ProfilesExplorerView/components/SceneCreateMetricModal/domain/useMenuOption.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneCreateMetricModal/domain/useMenuOption.ts
@@ -1,6 +1,7 @@
 import { IconName } from '@grafana/data';
 import { Props as FlameGraphProps } from '@grafana/flamegraph';
 import { t } from '@grafana/i18n';
+import { reportInteraction } from '@shared/domain/reportInteraction';
 import { DomainHookReturnValue } from '@shared/types/DomainHookReturnValue';
 import { useCallback } from 'react';
 
@@ -11,7 +12,10 @@ export function useCreateRecordingRulesMenu(setModalOpen: (functionName?: string
         {
           label: t('create-recording-rule.menu-option', 'Create recording rule'),
           icon: 'download-alt' as IconName,
-          onClick: () => setModalOpen(label === 'total' && item.level === 0 ? undefined : label),
+          onClick: () => {
+            reportInteraction('g_pyroscope_app_recording_rule_create_modal_opened');
+            setModalOpen(label === 'total' && item.level === 0 ? undefined : label);
+          },
         },
       ];
     },

--- a/src/pages/RecordingRulesView/domain/useRecordingRulesView.ts
+++ b/src/pages/RecordingRulesView/domain/useRecordingRulesView.ts
@@ -1,4 +1,5 @@
 import { displayError, displaySuccess } from '@shared/domain/displayStatus';
+import { reportInteraction } from '@shared/domain/reportInteraction';
 import { useFetchRecordingRules } from '@shared/infrastructure/recording-rules/useFetchRecordingRules';
 import { RecordingRuleViewModel } from '@shared/types/RecordingRuleViewModel';
 
@@ -15,6 +16,7 @@ export function useRecordingRulesView() {
       async removeRecordingRule(rule: RecordingRuleViewModel) {
         try {
           await remove(rule);
+          reportInteraction('g_pyroscope_app_recording_rule_deleted');
           displaySuccess([`Recording rule ${rule.metricName} deleted!`]);
         } catch (e) {
           displayError(e as Error, [`Failed to delete recording rule ${rule.metricName}.`]);

--- a/src/pages/SettingsView/components/UISettingsView/domain/__tests__/useUISettingsView.spec.ts
+++ b/src/pages/SettingsView/components/UISettingsView/domain/__tests__/useUISettingsView.spec.ts
@@ -15,6 +15,11 @@ jest.mock('@grafana/runtime', () => ({
   getAppEvents: () => appEvents,
 }));
 
+// reportInteraction dependency
+jest.mock('@shared/domain/reportInteraction', () => ({
+  reportInteraction: jest.fn(),
+}));
+
 // useFetchPluginSettings dependency
 const mutate = jest.fn();
 

--- a/src/pages/SettingsView/components/UISettingsView/domain/useUISettingsView.ts
+++ b/src/pages/SettingsView/components/UISettingsView/domain/useUISettingsView.ts
@@ -1,4 +1,5 @@
 import { displayError, displaySuccess } from '@shared/domain/displayStatus';
+import { reportInteraction } from '@shared/domain/reportInteraction';
 import { useMaxNodesFromUrl } from '@shared/domain/url-params/useMaxNodesFromUrl';
 import { DEFAULT_SETTINGS, PluginSettings } from '@shared/infrastructure/settings/PluginSettings';
 import { useFetchPluginSettings } from '@shared/infrastructure/settings/useFetchPluginSettings';
@@ -57,6 +58,7 @@ export function useUISettingsView() {
         try {
           await mutate(currentSettings);
 
+          reportInteraction('g_pyroscope_app_settings_saved');
           displaySuccess(['Plugin settings successfully saved!']);
         } catch (error) {
           displayError(error as Error, [

--- a/src/shared/domain/reportInteraction.ts
+++ b/src/shared/domain/reportInteraction.ts
@@ -84,10 +84,14 @@ export type Interactions = {
   };
   g_pyroscope_app_profile_metric_selected: {};
   g_pyroscope_app_quick_filter_focused: {};
+  g_pyroscope_app_recording_rule_create_modal_opened: {};
+  g_pyroscope_app_recording_rule_created: {};
+  g_pyroscope_app_recording_rule_deleted: {};
   g_pyroscope_app_select_action_clicked: {
     type: ActionType;
   };
   g_pyroscope_app_service_name_selected: {};
+  g_pyroscope_app_settings_saved: {};
   g_pyroscope_app_share_link_clicked: {};
   g_pyroscope_app_timeseries_scale_changed: {
     scale: ScaleDistribution;

--- a/src/shared/infrastructure/tracking/faro/__tests__/faro.spec.ts
+++ b/src/shared/infrastructure/tracking/faro/__tests__/faro.spec.ts
@@ -6,6 +6,9 @@ import { initFaro, setFaro } from '../faro';
 
 // Faro dependencies
 jest.mock('@grafana/faro-web-sdk');
+jest.mock('../interactionEchoBackend', () => ({
+  registerFaroInteractionEchoBackend: jest.fn(),
+}));
 
 // Grafana dependency
 jest.mock('@grafana/runtime', () => ({

--- a/src/shared/infrastructure/tracking/faro/faro.ts
+++ b/src/shared/infrastructure/tracking/faro/faro.ts
@@ -4,6 +4,7 @@ import { config } from '@grafana/runtime';
 import { PLUGIN_BASE_URL, PYROSCOPE_APP_ID } from '../../../../constants';
 import { GIT_COMMIT } from '../../../../version';
 import { getFaroEnvironment } from './getFaroEnvironment';
+import { registerFaroInteractionEchoBackend } from './interactionEchoBackend';
 
 let faro: Faro | null = null;
 
@@ -60,4 +61,7 @@ export function initFaro() {
       },
     })
   );
+
+  // mirror this plugin's reportInteraction events into faro
+  registerFaroInteractionEchoBackend();
 }

--- a/src/shared/infrastructure/tracking/faro/interactionEchoBackend.ts
+++ b/src/shared/infrastructure/tracking/faro/interactionEchoBackend.ts
@@ -1,3 +1,4 @@
+import { stringifyObjectValues } from '@grafana/faro-core';
 import { EchoBackend, EchoEventType, InteractionEchoEvent, registerEchoBackend } from '@grafana/runtime';
 
 import { getFaro } from './faro';
@@ -8,20 +9,6 @@ const PLUGIN_INTERACTION_PREFIXES = ['g_pyroscope_app_', 'grafana_profiles_app_'
 
 const isPluginInteraction = (interactionName: string) =>
   PLUGIN_INTERACTION_PREFIXES.some((prefix) => interactionName.startsWith(prefix));
-
-// faro event attributes must be strings
-const toEventAttributes = (properties: Record<string, unknown> = {}): Record<string, string> => {
-  const attributes: Record<string, string> = {};
-
-  for (const [key, value] of Object.entries(properties)) {
-    if (value === undefined || value === null) {
-      continue;
-    }
-    attributes[key] = typeof value === 'object' ? JSON.stringify(value) : String(value);
-  }
-
-  return attributes;
-};
 
 // echo backend that mirrors this plugin's reportInteraction events into faro as events.
 // EchoSrv fans every interaction out to registered backends, so we filter to our own names
@@ -36,7 +23,8 @@ class FaroInteractionEchoBackend implements EchoBackend<InteractionEchoEvent, {}
       return;
     }
 
-    getFaro()?.api.pushEvent(interactionName, toEventAttributes(properties));
+    // faro event attributes must be strings
+    getFaro()?.api.pushEvent(interactionName, stringifyObjectValues(properties));
   };
 
   // faro batches and sends internally, nothing to flush here

--- a/src/shared/infrastructure/tracking/faro/interactionEchoBackend.ts
+++ b/src/shared/infrastructure/tracking/faro/interactionEchoBackend.ts
@@ -1,0 +1,55 @@
+import { EchoBackend, EchoEventType, InteractionEchoEvent, registerEchoBackend } from '@grafana/runtime';
+
+import { getFaro } from './faro';
+
+// interaction names owned by this plugin: the typed wrapper uses g_pyroscope_app_*,
+// older saved-searches call sites use grafana_profiles_app_*
+const PLUGIN_INTERACTION_PREFIXES = ['g_pyroscope_app_', 'grafana_profiles_app_'];
+
+const isPluginInteraction = (interactionName: string) =>
+  PLUGIN_INTERACTION_PREFIXES.some((prefix) => interactionName.startsWith(prefix));
+
+// faro event attributes must be strings
+const toEventAttributes = (properties: Record<string, unknown> = {}): Record<string, string> => {
+  const attributes: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(properties)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+    attributes[key] = typeof value === 'object' ? JSON.stringify(value) : String(value);
+  }
+
+  return attributes;
+};
+
+// echo backend that mirrors this plugin's reportInteraction events into faro as events.
+// EchoSrv fans every interaction out to registered backends, so we filter to our own names
+class FaroInteractionEchoBackend implements EchoBackend<InteractionEchoEvent, {}> {
+  options = {};
+  supportedEvents = [EchoEventType.Interaction];
+
+  addEvent = (event: InteractionEchoEvent) => {
+    const { interactionName, properties } = event.payload;
+
+    if (!isPluginInteraction(interactionName)) {
+      return;
+    }
+
+    getFaro()?.api.pushEvent(interactionName, toEventAttributes(properties));
+  };
+
+  // faro batches and sends internally, nothing to flush here
+  flush = () => {};
+}
+
+let registered = false;
+
+export const registerFaroInteractionEchoBackend = () => {
+  if (registered) {
+    return;
+  }
+  registered = true;
+
+  registerEchoBackend(new FaroInteractionEchoBackend());
+};


### PR DESCRIPTION
### ✨ Description

Fixes:
Related issue(s):

we (frontend observability) are improving this plugin's faro dogfooding visibility by duplicating rudderstack (`reportInteraction`) events to faro, adding a few more custom events, and enabling features that should improve quality of life when using faro / frontend o11y.

two commits, intentionally separate:

1. `chore(faro): duplicate rudderstack events as faro events` — a small echo backend (registered via the public `registerEchoBackend()` API right after faro init) that mirrors this plugin's `reportInteraction` events into the plugin's faro instance as faro events. filters to the two interaction-name families this repo owns (`g_pyroscope_app_*` from the typed wrapper and the legacy `grafana_profiles_app_*` saved-searches call sites), stringifies attributes, and is a no-op when faro is disabled. rudderstack is unaffected.
2. `feat(tracking): add settings and recording-rule interaction events` — 4 new events for currently untracked high-value actions: `g_pyroscope_app_settings_saved`, `g_pyroscope_app_recording_rule_create_modal_opened`, `g_pyroscope_app_recording_rule_created`, `g_pyroscope_app_recording_rule_deleted`. kept as its own commit so it's easy to drop if unwanted. note: the wrapper's comment says new values should be added to your features tracking dashboard — that part is left to you.

notes:
- `isolate: true` and the page-url `beforeSend` filter were already in place — no changes needed there
- `experimental.trackNavigation` was skipped: the installed `@grafana/faro-web-sdk` 2.7.1 doesn't support it (2.8+ feature); worth picking up with a future faro bump

- [x] This pull request was substantially generated with AI assistance ([GenAI policy](https://github.com/grafana/profiles-drilldown/blob/main/docs/genai.md))

### 🧪 How to test?

1. run the plugin against a grafana with a faro environment configured (so `initFaro` initializes)
2. click around (e.g. save plugin settings, create/delete a recording rule, any tracked interaction)
3. faro collector requests in the network tab should contain the interaction names as faro events with stringified attrs, alongside the existing rudderstack calls

### user journey dogfooding

mirroring these interactions into faro also unlocks [critical user journeys](https://ops.grafana-ops.net/a/grafana-kowalski-app/apps/22/critical-journeys) for this app — journeys are built from faro events, so the duplicated interaction events can be used directly as journey steps to measure completion and drop-off of real product flows.
