### PR TITLE
feat: copy gcx pprof commands

### DIFF
--- a/src/locales/en-US/grafana-pyroscope-app.json
+++ b/src/locales/en-US/grafana-pyroscope-app.json
@@ -118,8 +118,10 @@
       "tooltip-time-picker": "Time picker",
       "tooltip-time-picker-description": "Time range zoom in (default behaviour)"
     },
+    "error-gcx-copy": "Failed to copy gcx commands to clipboard!",
     "error-loading-profile": "Error while loading profile data!",
     "explain-button": "Explain Diff Flame Graph",
+    "gcx-copied": "gcx commands copied to clipboard!",
     "missing-selections": {
       "auto-select": "Auto-select",
       "how-to-alt": "How to view the diff flame graph",
@@ -183,10 +185,16 @@
   "export-menu": {
     "aria-label": "Export profile data",
     "error-flamegraph-com": "Failed to export to flamegraph.com!",
+    "error-gcx-copy": "Failed to copy gcx command to clipboard!",
     "error-loading-profile": "Error while loading flamebearer profile data!",
     "error-png": "Failed to export to png!",
     "error-png-no-canvas": "Please ensure the flame graph is visible before exporting to png.",
     "error-pprof": "Failed to export to pprof!",
+    "gcx-command": "gcx command",
+    "gcx-command-tooltip": "Copy the gcx command to download this profile as pprof",
+    "gcx-commands": "gcx commands",
+    "gcx-commands-tooltip": "Copy the gcx commands to download the baseline and comparison profiles as pprof",
+    "gcx-copied": "gcx command copied to clipboard!",
     "json": "json",
     "json-label": "json",
     "png": "png",

--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneDiffFlameGraph/SceneDiffFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneDiffFlameGraph/SceneDiffFlameGraph.tsx
@@ -4,9 +4,12 @@ import { t, Trans } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { Spinner, useStyles2 } from '@grafana/ui';
 import { FlameGraph } from '@shared/components/FlameGraph/FlameGraph';
+import { displayError, displaySuccess } from '@shared/domain/displayStatus';
 import { reportInteraction } from '@shared/domain/reportInteraction';
+import { useMaxNodesFromUrl } from '@shared/domain/url-params/useMaxNodesFromUrl';
 import { useToggleSidePanel } from '@shared/domain/useToggleSidePanel';
 import { getProfileMetric, ProfileMetricId } from '@shared/infrastructure/profile-metrics/getProfileMetric';
+import { DEFAULT_SETTINGS } from '@shared/infrastructure/settings/PluginSettings';
 import { useFetchPluginSettings } from '@shared/infrastructure/settings/useFetchPluginSettings';
 import { DomainHookReturnValue } from '@shared/types/DomainHookReturnValue';
 import { FlamebearerProfile } from '@shared/types/FlamebearerProfile';
@@ -15,6 +18,8 @@ import { Panel } from '@shared/ui/Panel/Panel';
 import { PyroscopeLogo } from '@shared/ui/PyroscopeLogo';
 import React, { useEffect, useMemo } from 'react';
 
+import { buildGcxPprofCommand } from '../../../../domain/buildGcxPprofCommand';
+import { getPprofExportFilename } from '../../../../domain/getPprofExportFilename';
 import { useBuildPyroscopeQuery } from '../../../../domain/useBuildPyroscopeQuery';
 import { useGrafanaAssistant } from '../../../../domain/useGrafanaAssistant';
 import { ProfilesDataSourceVariable } from '../../../../domain/variables/ProfilesDataSourceVariable';
@@ -65,6 +70,7 @@ export class SceneDiffFlameGraph extends SceneObjectBase<SceneDiffFlameGraphStat
     const comparisonQuery = useBuildPyroscopeQuery(this, 'filtersComparison');
 
     const { settings } = useFetchPluginSettings();
+    const [maxNodes] = useMaxNodesFromUrl();
 
     const dataSourceUid = sceneGraph.findByKeyAndType(this, 'dataSource', ProfilesDataSourceVariable).useState()
       .value as string;
@@ -101,6 +107,35 @@ export class SceneDiffFlameGraph extends SceneObjectBase<SceneDiffFlameGraphStat
     );
     const hasMissingSelections = !isDiffQueryEnabled;
 
+    const copyGcxCommands = async () => {
+      const effectiveMaxNodes = maxNodes || DEFAULT_SETTINGS.maxNodes;
+      const baselineCommand = buildGcxPprofCommand({
+        dataSourceUid,
+        query: baselineQuery,
+        timeRange: baselineTimeRange,
+        maxNodes: effectiveMaxNodes,
+        filename: `${getPprofExportFilename(baselineQuery, baselineTimeRange)}_baseline.pb.gz`,
+      });
+      const comparisonCommand = buildGcxPprofCommand({
+        dataSourceUid,
+        query: comparisonQuery,
+        timeRange: comparisonTimeRange,
+        maxNodes: effectiveMaxNodes,
+        filename: `${getPprofExportFilename(comparisonQuery, comparisonTimeRange)}_comparison.pb.gz`,
+      });
+
+      try {
+        await navigator.clipboard.writeText(`${baselineCommand}\n${comparisonCommand}`);
+        reportInteraction('g_pyroscope_app_export_profile', { format: 'gcx' });
+        displaySuccess([t('diff-flame-graph.gcx-copied', 'gcx commands copied to clipboard!')]);
+      } catch (error) {
+        displayError(error as Error, [
+          t('diff-flame-graph.error-gcx-copy', 'Failed to copy gcx commands to clipboard!'),
+          (error as Error).message,
+        ]);
+      }
+    };
+
     return {
       data: {
         title: this.buildTitle(),
@@ -111,6 +146,7 @@ export class SceneDiffFlameGraph extends SceneObjectBase<SceneDiffFlameGraphStat
         hasMissingSelections,
         profile: profile as FlamebearerProfile,
         settings,
+        copyGcxCommands,
         ai: {
           panel: aiPanel,
           fetchParams: [
@@ -223,6 +259,7 @@ export class SceneDiffFlameGraph extends SceneObjectBase<SceneDiffFlameGraphStat
               collapsedFlamegraphs={data.settings?.collapsedFlamegraphs}
               /** Grafana assistant does not support diff flame graphs yet, we will use LLM plugin if enabled */
               showAnalyzeWithAssistant={false}
+              onCopyGcxCommands={data.copyGcxCommands}
             />
           )}
         </Panel>

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
@@ -163,6 +163,8 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
           menu: exportMenu,
           query,
           timeRange: lastTimeRange,
+          profileIdSelector,
+          spanSelector,
         },
         ai: {
           panel: aiPanel,
@@ -300,6 +302,8 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
                   model={data.export.menu}
                   query={data.export.query}
                   timeRange={data.export.timeRange}
+                  profileIdSelector={data.export.profileIdSelector}
+                  spanSelector={data.export.spanSelector}
                 />
               }
               keepFocusOnDataChange

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneExportMenu/SceneExportMenu.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneExportMenu/SceneExportMenu.tsx
@@ -247,6 +247,7 @@ export class SceneExportMenu extends SceneObjectBase<SceneExportMenuState> {
             />
             <Menu.Item label={t('export-menu.json', 'json')} onClick={actions.downloadJson} />
             <Menu.Item label={t('export-menu.pprof', 'pprof')} onClick={actions.downloadPprof} />
+            <Menu.Divider />
             <Tooltip
               content={t('export-menu.gcx-command-tooltip', 'Copy the gcx command to download this profile as pprof')}
             >

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneExportMenu/SceneExportMenu.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneExportMenu/SceneExportMenu.tsx
@@ -251,7 +251,7 @@ export class SceneExportMenu extends SceneObjectBase<SceneExportMenuState> {
               content={t('export-menu.gcx-command-tooltip', 'Copy the gcx command to download this profile as pprof')}
             >
               <Menu.Item
-                icon="clipboard-alt"
+                icon="copy"
                 label={t('export-menu.gcx-command', 'gcx command')}
                 onClick={actions.copyGcxCommand}
               />

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneExportMenu/SceneExportMenu.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneExportMenu/SceneExportMenu.tsx
@@ -1,8 +1,8 @@
 import { TimeRange } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
-import { Button, Dropdown, Menu } from '@grafana/ui';
-import { displayError } from '@shared/domain/displayStatus';
+import { Button, Dropdown, Menu, Tooltip } from '@grafana/ui';
+import { displayError, displaySuccess } from '@shared/domain/displayStatus';
 import { reportInteraction } from '@shared/domain/reportInteraction';
 import { saveProfileJsonToFile } from '@shared/domain/saveProfileJsonToFile';
 import { useMaxNodesFromUrl } from '@shared/domain/url-params/useMaxNodesFromUrl';
@@ -15,6 +15,7 @@ import 'compression-streams-polyfill';
 import saveAs from 'file-saver';
 import React from 'react';
 
+import { buildGcxPprofCommand } from '../../../../domain/buildGcxPprofCommand';
 import { ProfilesDataSourceVariable } from '../../../../domain/variables/ProfilesDataSourceVariable';
 import { ProfileApiClient } from '../../../../infrastructure/profiles/ProfileApiClient';
 import { DataSourceProxyClientBuilder } from '../../../../infrastructure/series/http/DataSourceProxyClientBuilder';
@@ -27,6 +28,8 @@ interface SceneExportMenuState extends SceneObjectState {}
 type ExtraProps = {
   query: string;
   timeRange: TimeRange;
+  profileIdSelector?: string;
+  spanSelector?: string;
 };
 
 export class SceneExportMenu extends SceneObjectBase<SceneExportMenuState> {
@@ -90,7 +93,7 @@ export class SceneExportMenu extends SceneObjectBase<SceneExportMenuState> {
     return profile;
   }
 
-  useSceneExportMenu = ({ query, timeRange }: ExtraProps): DomainHookReturnValue => {
+  useSceneExportMenu = ({ query, timeRange, profileIdSelector, spanSelector }: ExtraProps): DomainHookReturnValue => {
     const dataSourceUid = sceneGraph.findByKeyAndType(this, 'dataSource', ProfilesDataSourceVariable).useState()
       .value as string;
 
@@ -153,6 +156,30 @@ export class SceneExportMenu extends SceneObjectBase<SceneExportMenuState> {
       saveAs(profile, filename);
     };
 
+    const copyGcxCommand = async () => {
+      const filename = `${getExportFilename(query, timeRange)}.pb.gz`;
+      const command = buildGcxPprofCommand({
+        dataSourceUid,
+        query,
+        timeRange,
+        maxNodes: maxNodes || DEFAULT_SETTINGS.maxNodes,
+        filename,
+        profileIds: profileIdSelector ? [profileIdSelector] : undefined,
+        spanIds: spanSelector ? [spanSelector] : undefined,
+      });
+
+      try {
+        await navigator.clipboard.writeText(command);
+        reportInteraction('g_pyroscope_app_export_profile', { format: 'gcx' });
+        displaySuccess([t('export-menu.gcx-copied', 'gcx command copied to clipboard!')]);
+      } catch (error) {
+        displayError(error as Error, [
+          t('export-menu.error-gcx-copy', 'Failed to copy gcx command to clipboard!'),
+          (error as Error).message,
+        ]);
+      }
+    };
+
     const uploadToFlamegraphDotCom = async () => {
       reportInteraction('g_pyroscope_app_export_profile', { format: 'flamegraph.com' });
 
@@ -195,6 +222,7 @@ export class SceneExportMenu extends SceneObjectBase<SceneExportMenuState> {
         downloadPng,
         downloadJson,
         downloadPprof,
+        copyGcxCommand,
         uploadToFlamegraphDotCom,
       },
     };
@@ -219,6 +247,15 @@ export class SceneExportMenu extends SceneObjectBase<SceneExportMenuState> {
             />
             <Menu.Item label={t('export-menu.json', 'json')} onClick={actions.downloadJson} />
             <Menu.Item label={t('export-menu.pprof', 'pprof')} onClick={actions.downloadPprof} />
+            <Tooltip
+              content={t('export-menu.gcx-command-tooltip', 'Copy the gcx command to download this profile as pprof')}
+            >
+              <Menu.Item
+                icon="clipboard-alt"
+                label={t('export-menu.gcx-command', 'gcx command')}
+                onClick={actions.copyGcxCommand}
+              />
+            </Tooltip>
           </Menu>
         }
       >

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneExportMenu/domain/getExportFilename.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneExportMenu/domain/getExportFilename.ts
@@ -1,8 +1,1 @@
-import { TimeRange } from '@grafana/data';
-import { parseQuery } from '@shared/domain/url-params/parseQuery';
-
-export function getExportFilename(query: string, timeRange: TimeRange) {
-  const { serviceId, profileMetricId } = parseQuery(query);
-  const dateString = `${timeRange.from.format('YYYY-MM-DD_HHmm')}-to-${timeRange.to.format('YYYY-MM-DD_HHmm')}`;
-  return `${serviceId.replace(/\//g, '-')}_${profileMetricId}_${dateString}`;
-}
+export { getPprofExportFilename as getExportFilename } from '../../../../../domain/getPprofExportFilename';

--- a/src/pages/ProfilesExplorerView/domain/__tests__/buildGcxPprofCommand.spec.ts
+++ b/src/pages/ProfilesExplorerView/domain/__tests__/buildGcxPprofCommand.spec.ts
@@ -1,0 +1,42 @@
+import { dateTimeParse } from '@grafana/data';
+
+import { buildGcxPprofCommand } from '../buildGcxPprofCommand';
+
+describe('buildGcxPprofCommand', () => {
+  it('builds a pprof command with the datasource, selector, exact range, and filename', () => {
+    const command = buildGcxPprofCommand({
+      dataSourceUid: 'pyroscope uid',
+      query: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds{service_name="api",env="prod"}',
+      timeRange: {
+        raw: { from: 'now-1h', to: 'now' },
+        from: dateTimeParse('2024-02-18T23:00:00.123Z'),
+        to: dateTimeParse('2024-02-19T00:00:00.456Z'),
+      },
+      maxNodes: 5000,
+      filename: 'api_process_cpu.pb.gz',
+      profileIds: ['550e8400-e29b-41d4-a716-446655440000', '7c9e6679-7425-40de-944b-e07fc1f90ae7'],
+      spanIds: ['00f067aa0ba902b7', '01f067aa0ba902b8'],
+    });
+
+    expect(command).toBe(
+      "gcx profiles query -d 'pyroscope uid' '{service_name=\"api\",env=\"prod\"}' --profile-type 'process_cpu:cpu:nanoseconds:cpu:nanoseconds' --from '2024-02-18T23:00:00.123Z' --to '2024-02-19T00:00:00.456Z' --max-nodes 5000 --profile-id '550e8400-e29b-41d4-a716-446655440000' --profile-id '7c9e6679-7425-40de-944b-e07fc1f90ae7' --span-id '00f067aa0ba902b7' --span-id '01f067aa0ba902b8' -o pprof --pprof-path 'api_process_cpu.pb.gz'"
+    );
+  });
+
+  it('shell-quotes generated arguments', () => {
+    const command = buildGcxPprofCommand({
+      dataSourceUid: "pyro'scope",
+      query: 'process_cpu{service_name="api"}',
+      timeRange: {
+        raw: { from: '1', to: '2' },
+        from: dateTimeParse(1000),
+        to: dateTimeParse(2000),
+      },
+      maxNodes: 1,
+      filename: "profile's.pb.gz",
+    });
+
+    expect(command).toContain(`-d 'pyro'\"'\"'scope'`);
+    expect(command).toContain(`--pprof-path 'profile'\"'\"'s.pb.gz'`);
+  });
+});

--- a/src/pages/ProfilesExplorerView/domain/buildGcxPprofCommand.ts
+++ b/src/pages/ProfilesExplorerView/domain/buildGcxPprofCommand.ts
@@ -1,0 +1,42 @@
+import { TimeRange } from '@grafana/data';
+import { parseQuery } from '@shared/domain/url-params/parseQuery';
+
+type BuildGcxPprofCommandOptions = {
+  dataSourceUid: string;
+  query: string;
+  timeRange: TimeRange;
+  maxNodes: number;
+  filename: string;
+  profileIds?: string[];
+  spanIds?: string[];
+};
+
+function shellQuote(value: string) {
+  return `'${value.replace(/'/g, "'\"'\"'")}'`;
+}
+
+export function buildGcxPprofCommand({
+  dataSourceUid,
+  query,
+  timeRange,
+  maxNodes,
+  filename,
+  profileIds = [],
+  spanIds = [],
+}: BuildGcxPprofCommandOptions) {
+  const { profileMetricId, labelsSelector } = parseQuery(query);
+
+  return [
+    'gcx profiles query',
+    `-d ${shellQuote(dataSourceUid)}`,
+    shellQuote(labelsSelector),
+    `--profile-type ${shellQuote(profileMetricId)}`,
+    `--from ${shellQuote(timeRange.from.toISOString())}`,
+    `--to ${shellQuote(timeRange.to.toISOString())}`,
+    `--max-nodes ${maxNodes}`,
+    ...profileIds.map((profileId) => `--profile-id ${shellQuote(profileId)}`),
+    ...spanIds.map((spanId) => `--span-id ${shellQuote(spanId)}`),
+    '-o pprof',
+    `--pprof-path ${shellQuote(filename)}`,
+  ].join(' ');
+}

--- a/src/pages/ProfilesExplorerView/domain/getPprofExportFilename.ts
+++ b/src/pages/ProfilesExplorerView/domain/getPprofExportFilename.ts
@@ -1,0 +1,8 @@
+import { TimeRange } from '@grafana/data';
+import { parseQuery } from '@shared/domain/url-params/parseQuery';
+
+export function getPprofExportFilename(query: string, timeRange: TimeRange) {
+  const { serviceId, profileMetricId } = parseQuery(query);
+  const dateString = `${timeRange.from.format('YYYY-MM-DD_HHmm')}-to-${timeRange.to.format('YYYY-MM-DD_HHmm')}`;
+  return `${serviceId.replace(/\//g, '-')}_${profileMetricId}_${dateString}`;
+}

--- a/src/shared/components/FlameGraph/FlameGraph.tsx
+++ b/src/shared/components/FlameGraph/FlameGraph.tsx
@@ -13,6 +13,7 @@ type FlameGraphProps = {
   diff?: boolean;
   vertical?: boolean;
   enableFlameGraphDotComExport?: boolean;
+  onCopyGcxCommands?: () => void | Promise<void>;
   collapsedFlamegraphs?: boolean;
   getExtraContextMenuButtons?: Props['getExtraContextMenuButtons'];
   showAnalyzeWithAssistant?: boolean;
@@ -23,6 +24,7 @@ function FlameGraphComponent({
   diff,
   vertical,
   enableFlameGraphDotComExport,
+  onCopyGcxCommands,
   collapsedFlamegraphs,
   getExtraContextMenuButtons,
   showAnalyzeWithAssistant,
@@ -46,7 +48,13 @@ function FlameGraphComponent({
     <GrafanaFlameGraph
       data={dataFrame as any}
       disableCollapsing={!collapsedFlamegraphs}
-      extraHeaderElements={<ExportData profile={profile} enableFlameGraphDotComExport={enableFlameGraphDotComExport} />}
+      extraHeaderElements={
+        <ExportData
+          profile={profile}
+          enableFlameGraphDotComExport={enableFlameGraphDotComExport}
+          onCopyGcxCommands={onCopyGcxCommands}
+        />
+      }
       vertical={vertical}
       getTheme={getTheme as any}
       getExtraContextMenuButtons={getExtraContextMenuButtons}

--- a/src/shared/components/FlameGraph/components/ExportData.tsx
+++ b/src/shared/components/FlameGraph/components/ExportData.tsx
@@ -8,13 +8,22 @@ import { ExportMenu } from './ExportMenu';
 export type ExportDataProps = {
   profile: FlamebearerProfile;
   enableFlameGraphDotComExport?: boolean;
+  onCopyGcxCommands?: () => void | Promise<void>;
 };
 
 function ExportDataComponent(props: ExportDataProps) {
-  const { profile, enableFlameGraphDotComExport } = props;
+  const { profile, enableFlameGraphDotComExport, onCopyGcxCommands } = props;
 
   return (
-    <Dropdown overlay={<ExportMenu profile={profile} enableFlameGraphDotComExport={enableFlameGraphDotComExport} />}>
+    <Dropdown
+      overlay={
+        <ExportMenu
+          profile={profile}
+          enableFlameGraphDotComExport={enableFlameGraphDotComExport}
+          onCopyGcxCommands={onCopyGcxCommands}
+        />
+      }
+    >
       <Button
         icon="download-alt"
         size="sm"

--- a/src/shared/components/FlameGraph/components/ExportMenu.tsx
+++ b/src/shared/components/FlameGraph/components/ExportMenu.tsx
@@ -29,7 +29,7 @@ export function ExportMenu(props: ExportDataProps) {
           )}
         >
           <Menu.Item
-            icon="clipboard-alt"
+            icon="copy"
             label={t('export-menu.gcx-commands', 'gcx commands')}
             onClick={props.onCopyGcxCommands}
           />

--- a/src/shared/components/FlameGraph/components/ExportMenu.tsx
+++ b/src/shared/components/FlameGraph/components/ExportMenu.tsx
@@ -22,18 +22,21 @@ export function ExportMenu(props: ExportDataProps) {
       />
       <Menu.Item label={t('export-menu.json-label', 'json')} onClick={actions.downloadJson} />
       {props.onCopyGcxCommands && (
-        <Tooltip
-          content={t(
-            'export-menu.gcx-commands-tooltip',
-            'Copy the gcx commands to download the baseline and comparison profiles as pprof'
-          )}
-        >
-          <Menu.Item
-            icon="copy"
-            label={t('export-menu.gcx-commands', 'gcx commands')}
-            onClick={props.onCopyGcxCommands}
-          />
-        </Tooltip>
+        <>
+          <Menu.Divider />
+          <Tooltip
+            content={t(
+              'export-menu.gcx-commands-tooltip',
+              'Copy the gcx commands to download the baseline and comparison profiles as pprof'
+            )}
+          >
+            <Menu.Item
+              icon="copy"
+              label={t('export-menu.gcx-commands', 'gcx commands')}
+              onClick={props.onCopyGcxCommands}
+            />
+          </Tooltip>
+        </>
       )}
     </Menu>
   );

--- a/src/shared/components/FlameGraph/components/ExportMenu.tsx
+++ b/src/shared/components/FlameGraph/components/ExportMenu.tsx
@@ -1,5 +1,5 @@
 import { t } from '@grafana/i18n';
-import { Menu } from '@grafana/ui';
+import { Menu, Tooltip } from '@grafana/ui';
 import React from 'react';
 
 import { useExportMenu } from './domain/useExportMenu';
@@ -21,6 +21,20 @@ export function ExportMenu(props: ExportDataProps) {
         onClick={actions.downloadPng}
       />
       <Menu.Item label={t('export-menu.json-label', 'json')} onClick={actions.downloadJson} />
+      {props.onCopyGcxCommands && (
+        <Tooltip
+          content={t(
+            'export-menu.gcx-commands-tooltip',
+            'Copy the gcx commands to download the baseline and comparison profiles as pprof'
+          )}
+        >
+          <Menu.Item
+            icon="clipboard-alt"
+            label={t('export-menu.gcx-commands', 'gcx commands')}
+            onClick={props.onCopyGcxCommands}
+          />
+        </Tooltip>
+      )}
     </Menu>
   );
 }

--- a/src/shared/components/FlameGraph/components/__tests__/ExportMenu.test.tsx
+++ b/src/shared/components/FlameGraph/components/__tests__/ExportMenu.test.tsx
@@ -41,4 +41,15 @@ describe('<ExportMenu />', () => {
       expect(screen.queryByText('Switch to the flame graph view to export it as a png')).not.toBeInTheDocument();
     });
   });
+
+  it('shows the gcx copy action only when commands are available', () => {
+    const onCopyGcxCommands = jest.fn();
+    const { rerender } = render(<ExportMenu profile={profile} />);
+
+    expect(screen.queryByText('gcx commands')).not.toBeInTheDocument();
+
+    rerender(<ExportMenu profile={profile} onCopyGcxCommands={onCopyGcxCommands} />);
+
+    expect(screen.getByText('gcx commands')).toBeInTheDocument();
+  });
 });

--- a/src/shared/domain/reportInteraction.ts
+++ b/src/shared/domain/reportInteraction.ts
@@ -57,7 +57,7 @@ export type Interactions = {
     source: 'trace-id' | 'action';
   };
   g_pyroscope_app_export_profile: {
-    format: 'png' | 'json' | 'pprof' | 'flamegraph.com';
+    format: 'png' | 'json' | 'pprof' | 'gcx' | 'flamegraph.com';
   };
   g_pyroscope_app_fav_action_clicked: {
     favAfterClick: boolean;


### PR DESCRIPTION
I find myself very often wanting to investigate a particular flamegraph further locally. This adds a copy GCX command to clipboard button to the single and the diff view.

Let me know how you feel about this

<img width="450" height="314" alt="image" src="https://github.com/user-attachments/assets/485b0870-9951-4ddf-86e3-da17232d27c8" />

<img width="580" height="291" alt="image" src="https://github.com/user-attachments/assets/7a00f957-4948-41cd-9e39-4bd84d12ff5e" />




