### PR TITLE
fix: stop rebuilding every grid panel when the item list changes

### DIFF
--- a/e2e/fixtures/pages/ExploreProfilesPage.ts
+++ b/e2e/fixtures/pages/ExploreProfilesPage.ts
@@ -71,6 +71,14 @@ export class ExploreProfilesPage extends PyroscopePage {
     await this.getByTestId('data-testid TimePicker Overlay Content').getByText(quickRangeLabel).click();
   }
 
+  getZoomOutButton() {
+    return this.getByLabel('Zoom out time range');
+  }
+
+  clickOnZoomOut() {
+    return this.getZoomOutButton().click();
+  }
+
   getRefreshPicker() {
     return this.getByTestId('data-testid RefreshPicker run button');
   }
@@ -330,6 +338,28 @@ export class ExploreProfilesPage extends PyroscopePage {
       const height = await sceneBody.evaluate((el) => (el as HTMLElement).offsetHeight);
       expect(height).toBeGreaterThanOrEqual(600);
     }).toPass({ timeout: 15000 });
+  }
+
+  /**
+   * Marks the panel DOM nodes that are currently mounted. The marker is an expando property, which
+   * survives re-renders but not an unmount/remount, so counting the survivors after an interaction
+   * tells us whether the grid reused its panels or tore them all down and rebuilt them.
+   */
+  tagMountedPanels() {
+    return this.getSceneBody().evaluate((body) => {
+      body.querySelectorAll('[data-viz-panel-key]').forEach((el) => {
+        (el as HTMLElement & { __e2ePanelTag?: boolean }).__e2ePanelTag = true;
+      });
+    });
+  }
+
+  countTaggedPanels() {
+    return this.getSceneBody().evaluate(
+      (body) =>
+        Array.from(body.querySelectorAll('[data-viz-panel-key]')).filter(
+          (el) => (el as HTMLElement & { __e2ePanelTag?: boolean }).__e2ePanelTag
+        ).length
+    );
   }
 
   getPanelByTitle(title: string) {

--- a/e2e/tests/all-services-view/all-services.spec.ts
+++ b/e2e/tests/all-services-view/all-services.spec.ts
@@ -41,6 +41,38 @@ test.describe('All services view', () => {
     await expect(exploreProfilesPage.getPanelByTitle('ride-sharing-app')).toBeVisible();
   });
 
+  test.describe('Panel reuse', () => {
+    test('Narrowing the list keeps the matching panels mounted', async ({ exploreProfilesPage }) => {
+      await expect(exploreProfilesPage.getPanels()).toHaveCount(3);
+
+      await exploreProfilesPage.tagMountedPanels();
+
+      await exploreProfilesPage.enterQuickFilterText('sharing,load');
+      await expect(exploreProfilesPage.getPanels()).toHaveCount(2);
+
+      // both matching services were already on screen, so the grid must keep their panels rather
+      // than rebuild every item: rebuilding unmounts the whole grid and blanks it before it refills
+      expect(await exploreProfilesPage.countTaggedPanels()).toBe(2);
+    });
+
+    test('Time range change keeps the panels mounted when the service list is unchanged', async ({
+      exploreProfilesPage,
+    }) => {
+      await expect(exploreProfilesPage.getPanels()).toHaveCount(3);
+
+      await exploreProfilesPage.tagMountedPanels();
+
+      await exploreProfilesPage.clickOnZoomOut();
+
+      await expect(exploreProfilesPage.getTimePickerButton()).not.toContainText(
+        '2024-03-13 19:00:00 to 2024-03-13 19:50:00'
+      );
+      await expect(exploreProfilesPage.getPanels()).toHaveCount(3);
+
+      expect(await exploreProfilesPage.countTaggedPanels()).toBe(3);
+    });
+  });
+
   test('Layout switcher', async ({ exploreProfilesPage }) => {
     await exploreProfilesPage.selectLayout('Rows');
 

--- a/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
@@ -53,8 +53,13 @@ const GRID_TEMPLATE_ROWS = '1fr';
 const GRID_AUTO_ROWS = '240px';
 
 export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariableRepeaterGridState> {
+  /**
+   * Identifies a panel by what it queries, so that renderGridItems() can recognize the panels it
+   * can keep. `index` is deliberately left out: it only drives panel colors and shifts for every
+   * item whenever the list grows or shrinks, which would make every panel look new.
+   */
   static buildGridItemKey(item: GridItemData) {
-    return `grid-item-${item.index}-${item.value}`;
+    return `grid-item-${item.value}-${item.panelType}-${JSON.stringify(item.queryRunnerParams)}`;
   }
 
   static getGridColumnsTemplate(layout: LayoutType) {
@@ -242,6 +247,43 @@ export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariable
     return !isEqual(items, newItems);
   }
 
+  /**
+   * Indexes the panels that are already on screen so that renderGridItems() can keep the ones that
+   * still query the same thing. Replacing every child unmounts the whole grid, which blanks the
+   * page and restarts every query each time the time range or the filters change.
+   *
+   * A forced render intentionally reuses nothing: it is how panels (re)attach the "no data"
+   * subscription set up in setupHideNoData().
+   */
+  private collectReusablePanels(forceRender: boolean) {
+    const reusablePanels = new Map<string, SceneCSSGridLayout['state']['children'][number]>();
+
+    if (forceRender) {
+      return reusablePanels;
+    }
+
+    for (const child of (this.state.body as SceneCSSGridLayout).state.children) {
+      if (child.state.key) {
+        reusablePanels.set(child.state.key, child);
+      }
+    }
+
+    return reusablePanels;
+  }
+
+  private buildGridItem(item: GridItemData, key: string) {
+    const vizPanel = vizPanelBuilder(item.panelType, {
+      item,
+      headerActions: this.state.headerActions.bind(null, item, this.state.items),
+    });
+
+    if (this.state.hideNoData) {
+      this.setupHideNoData(vizPanel);
+    }
+
+    return new SceneCSSGridItem({ key, body: vizPanel });
+  }
+
   renderGridItems(forceRender = false) {
     const variable = sceneGraph.lookupVariable(this.state.variableName, this) as QueryVariable;
 
@@ -267,23 +309,15 @@ export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariable
       return;
     }
 
+    const grid = this.state.body as SceneCSSGridLayout;
+    const reusablePanels = this.collectReusablePanels(forceRender);
+
     const gridItems = this.state.items.map((item) => {
-      const vizPanel = vizPanelBuilder(item.panelType, {
-        item,
-        headerActions: this.state.headerActions.bind(null, item, this.state.items),
-      });
-
-      if (this.state.hideNoData) {
-        this.setupHideNoData(vizPanel);
-      }
-
-      return new SceneCSSGridItem({
-        key: SceneByVariableRepeaterGrid.buildGridItemKey(item),
-        body: vizPanel,
-      });
+      const key = SceneByVariableRepeaterGrid.buildGridItemKey(item);
+      return reusablePanels.get(key) ?? this.buildGridItem(item, key);
     });
 
-    (this.state.body as SceneCSSGridLayout).setState({
+    grid.setState({
       autoRows: GRID_AUTO_ROWS, // required to have the correct grid items height
       children: gridItems,
     });


### PR DESCRIPTION
### ✨ Description

Fixes: n/a (reported internally, video below)

Changing the time range on "All services" blanks the entire grid before it refills. With 3000+ services that is a visible flicker plus a full re-query on every interaction.

`ServiceNameVariable` refreshes on every time range change (`VariableRefresh.onTimeRangeChanged`), and when it settles `renderGridItems()` replaced `SceneCSSGridLayout.children` with freshly constructed panels for *every* item. React unmounts the whole grid, then the lazy loader remounts the visible panels and restarts their queries.

This reconciles instead: panels already on screen that still query the same thing are kept. `buildGridItemKey()` no longer includes `index`, which is colour-only metadata that shifts for every item whenever the list grows or shrinks. A forced render still rebuilds, because that is how panels attach the `setupHideNoData()` subscription.

Notes:
- `SceneLabelValuesGrid` has its own copy of the same wholesale-replace logic and still rebuilds; not touched here.

- [x] This pull request was substantially generated with AI assistance ([GenAI policy](https://github.com/grafana/profiles-drilldown/blob/main/docs/genai.md))

### 🧪 How to test?

New e2e test `Panel reuse › Narrowing the list keeps the matching panels mounted` fails on main (`Expected: 2, Received: 0`) and passes here.

The recording below is a single run of the same script against a stack with 3000+ services, before on the left and after on the right, switching Last 30 minutes → Last 2 days → Last 24 hours.

https://github.com/user-attachments/assets/f6f76d14-fe52-4c72-921a-51b11424dea5

