### PR TITLE
fix(deps): resolve pnpm audit vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,10 +16,11 @@ overrides:
   minimatch@^5: ~5.1.9
   minimatch@^9: ~9.0.9
   ajv@^8: ~8.18.0
-  dompurify: ~3.4.12
-  hono: '>=4.12.27'
+  dompurify: ~3.4.13
+  hono: '>=4.12.34'
   '@hono/node-server': 2.0.11
-  js-yaml@^4: ~4.3.0
+  js-yaml@^3: ~3.15.1
+  js-yaml@^4: ~4.3.1
   '@opentelemetry/core': '>=2.8.0'
   immutable: ~5.1.8
   js-cookie: '>=3.0.7'
@@ -35,6 +36,7 @@ overrides:
   serialize-javascript: ~7.0.5
   uuid: '>=11.1.1'
   ws: '>=8.20.1'
+  nanoid@^3: '>=3.3.17 <4'
 
 importers:
 
@@ -983,7 +985,7 @@ packages:
     resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: '>=4.12.27'
+      hono: '>=4.12.34'
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -3080,8 +3082,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -3681,8 +3683,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.12.31:
-    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
+  hono@4.13.0:
+    resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@4.0.0:
@@ -4226,12 +4228,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdoc-type-pratt-parser@7.1.1:
@@ -4523,8 +4525,8 @@ packages:
       react: '*'
       react-dom: '*'
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4986,6 +4988,7 @@ packages:
 
   react-grid-layout@1.5.3:
     resolution: {integrity: sha512-KaG6IbjD6fYhagUtIvOzhftXG+ViKZjCjADe86X1KHl7C/dsBN2z0mi14nbvZKTkp0RKiil9RPcJBgq3LnoA8g==}
+    deprecated: 'Ships stray files that were never in the repo: an ip_fetcher binary and its curl-sample source (1.5.0-1.5.3), plus a yarn-error.log containing local paths (1.5.3). Upgrade to 1.5.4, which is byte-identical apart from removing them. See https://github.com/react-grid-layout/react-grid-layout/issues/2269'
     peerDependencies:
       react: '>= 16.3.0'
       react-dom: '>= 16.3.0'
@@ -6816,7 +6819,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -6919,7 +6922,7 @@ snapshots:
       d3-interpolate: 3.0.1
       d3-scale-chromatic: 3.1.0
       date-fns: 4.1.0
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       eventemitter3: 5.0.1
       history: 4.10.1
       lodash: 4.18.1
@@ -7211,9 +7214,9 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@hono/node-server@2.0.11(hono@4.12.31)':
+  '@hono/node-server@2.0.11(hono@4.13.0)':
     dependencies:
-      hono: 4.12.31
+      hono: 4.13.0
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -7381,7 +7384,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -7643,7 +7646,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.0.11(hono@4.12.31)
+      '@hono/node-server': 2.0.11(hono@4.13.0)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -7653,7 +7656,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.31
+      hono: 4.13.0
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -9501,7 +9504,7 @@ snapshots:
       '@babel/runtime': 7.29.7
       csstype: 3.2.3
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -10292,7 +10295,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.12.31: {}
+  hono@4.13.0: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:
@@ -11046,12 +11049,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -11136,7 +11139,7 @@ snapshots:
       enhanced-resolve: 5.24.0
       fast-glob: 3.3.3
       jiti: 2.7.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimist: 1.2.8
       picocolors: 1.1.1
       picomatch: 4.0.4
@@ -11314,7 +11317,7 @@ snapshots:
       stacktrace-js: 2.0.2
       stylis: 4.4.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -11612,7 +11615,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,10 +36,11 @@ overrides:
   minimatch@^5: ~5.1.9
   minimatch@^9: ~9.0.9
   ajv@^8: ~8.18.0
-  dompurify: ~3.4.12
-  hono: '>=4.12.27'
+  dompurify: ~3.4.13
+  hono: '>=4.12.34'
   '@hono/node-server': 2.0.11
-  js-yaml@^4: ~4.3.0
+  js-yaml@^3: ~3.15.1
+  js-yaml@^4: ~4.3.1
   '@opentelemetry/core': '>=2.8.0'
   immutable: ~5.1.8
   js-cookie: '>=3.0.7'
@@ -55,3 +56,4 @@ overrides:
   serialize-javascript: ~7.0.5
   uuid: '>=11.1.1'
   ws: '>=8.20.1'
+  nanoid@^3: '>=3.3.17 <4'


### PR DESCRIPTION
## Summary

Updates pnpm overrides in `pnpm-workspace.yaml` to resolve `pnpm audit` findings.

**Audit: 11 vulnerabilities (3 high, 7 moderate, 1 low) -> 3 (3 moderate).**

| Package | Before | After | Advisory |
| --- | --- | --- | --- |
| `dompurify` | `~3.4.12` | `~3.4.13` | GHSA-55q2-fjhq-7xh7 |
| `js-yaml@^4` | `~4.3.0` | `~4.3.1` | GHSA-5p4m-2wfm-xmqj |
| `js-yaml@^3` | _(new)_ | `~3.15.1` | GHSA-5p4m-2wfm-xmqj |
| `nanoid@^3` | _(new)_ | `>=3.3.17 <4` | GHSA-2v37-7h3g-55p8 |
| `hono` | `>=4.12.27` | `>=4.12.34` (resolves `4.13.0`; `@hono/node-server@2.0.11` peers `hono: ^4`) | GHSA-8j4g-w8fx-2239, GHSA-f23p-vx2j-j53r, GHSA-54fx-42gc-7vw4, GHSA-79qm-7rj5-m7r9 |

### Notes on override key choice

`pnpm why` was used to check how many majors are actually in the tree before choosing bare vs scoped keys:

- **`js-yaml` has two majors present** and gets one scoped key per line. `3.15.0` comes in via `@istanbuljs/load-nyc-config` (which declares `^3.13.1`), `4.3.0` via `eslint`. A bare `js-yaml` key would collapse the 3.x copy onto 4.x and break its dependents.
- **`nanoid` is bounded to `<4`.** An unbounded `>=3.3.17` resolved to `6.0.1`, a three-major jump for `postcss` (which declares `^3.3.16`). The bound keeps it on the patched 3.x line.
- **`hono`** was not in the original scan list but is flagged by four advisories; the existing override floor was below the patch. The lockfile had pinned `4.12.31` despite the override, so this also re-syncs it.

## Known remaining (no installable patch)

These 3 moderate findings are **not fixable via overrides** and are intentionally left alone rather than suppressed:

- **`react-router-dom`** — GHSA-jjmj-jmhj-qwj2, patched `>=6.30.5`. **`6.30.5` was never published**; the 6.x line dead-ends at the flagged `6.30.4`. There is no installable patch on 6.x.
- **`react-router`** (x2) — GHSA-wrjc-x8rr-h8h6, GHSA-337j-9hxr-rhxg, patched `>=7.18.0`. The tree contains only `5.3.4` and `6.30.4` (via `@grafana/ui`, `@grafana/scenes`, `react-router-dom-v5-compat`) — **no 7.x at all**. An override to `>=7.18.0` would collapse both older majors onto 7.x and break those dependents.

The real fix is the major upgrade already open in **#1064** (`react-router-dom` -> v7). `react-router-dom` is a direct dependency here (`^6.30.3`, imported in 4 source files), so that migration belongs in its own PR.

## Related open CVE PRs

- **#1086** (`fix/cve-08-04-26`) — draft, currently `CONFLICTING`/behind `main`. Superseded by this PR; can be closed.
- **#1059** (`fix/cve-07-22-26`) — older CVE PR, also overlapping. Worth closing or refreshing.
- **#1064** — Renovate `react-router-dom` v7 security upgrade; resolves the remaining 3 findings above.

## Test plan

- [x] `pnpm install --frozen-lockfile` (what CI runs) exits 0; lockfile passes supply-chain policies (`frozenLockfile`, `minimumReleaseAge`, `trustPolicy`, `blockExoticSubdeps`)
- [x] `pnpm audit` down from 11 to 3, all remaining documented above as unpatchable
- [x] `pnpm run typecheck` passes
- [x] `pnpm run build` passes
- [x] Verified resolved tree: `js-yaml@3.15.1` + `js-yaml@4.3.1` both present on their own majors, `nanoid@3.3.17`, `dompurify@3.4.13`
- [x] No `minimumReleaseAgeExclude` entries needed — every resolved patch (`js-yaml@3.15.1`/`4.3.1`, `dompurify@3.4.13`, `nanoid@3.3.17`, `hono@4.13.0`) was published 2026-07-31..08-03, clearing the 5-day gate
