### PR TITLE
fix: scope diff view filters to their own panel time range

### DIFF
--- a/e2e/fixtures/pages/ExploreProfilesPage.ts
+++ b/e2e/fixtures/pages/ExploreProfilesPage.ts
@@ -428,6 +428,17 @@ export class ExploreProfilesPage extends PyroscopePage {
     }
   }
 
+  /** Opens the filter input and returns the suggestions menu, which lists the labels found in the current time range. */
+  async openFilterSuggestions(filterKey = 'filters') {
+    await this.getFilters(filterKey).getByRole('combobox').click();
+
+    return this.getByLabel('Select options menu');
+  }
+
+  closeFilterSuggestions() {
+    return this.page.keyboard.press('Escape');
+  }
+
   /* Flame graph component */
 
   getSpanProfileVisualizationPicker() {
@@ -571,6 +582,11 @@ export class ExploreProfilesPage extends PyroscopePage {
 
   getComparisonTimePickerButton(target: 'baseline' | 'comparison') {
     return this.getByTestId(`panel-${target}`).getByTestId('data-testid TimePicker Open Button');
+  }
+
+  async selectComparisonQuickRange(target: 'baseline' | 'comparison', quickRangeLabel: string) {
+    await this.getComparisonTimePickerButton(target).click();
+    await this.getByTestId('data-testid TimePicker Overlay Content').getByText(quickRangeLabel).click();
   }
 
   async selectComparisonTimeRange(target: 'baseline' | 'comparison', from: string, to: string) {

--- a/e2e/tests/diff-flame-graph-view/diff-flame-graph.spec.ts
+++ b/e2e/tests/diff-flame-graph-view/diff-flame-graph.spec.ts
@@ -129,6 +129,30 @@ test.describe('Diff flame graph view', () => {
     });
   });
 
+  test.describe('Filter suggestions', () => {
+    // see https://github.com/grafana/profiles-drilldown/issues/821
+    test('Each panel suggests the labels found in its own time range', async ({ exploreProfilesPage }) => {
+      await expect(await exploreProfilesPage.openFilterSuggestions('filtersComparison')).toContainText('vehicle');
+      await exploreProfilesPage.closeFilterSuggestions();
+
+      // the static test data is from 2024-03-13, so this range contains no profiles at all
+      await exploreProfilesPage.selectComparisonQuickRange('comparison', 'Last 5 minutes');
+
+      const comparisonSuggestions = await exploreProfilesPage.openFilterSuggestions('filtersComparison');
+
+      await expect(comparisonSuggestions).not.toContainText('Loading...');
+      await expect(comparisonSuggestions.getByRole('option')).toHaveCount(0);
+
+      await exploreProfilesPage.closeFilterSuggestions();
+
+      // the baseline panel still has the original time range
+      const baselineSuggestions = await exploreProfilesPage.openFilterSuggestions('filtersBaseline');
+
+      await expect(baselineSuggestions.getByRole('option').first()).toBeVisible();
+      await expect(baselineSuggestions).toContainText('vehicle');
+    });
+  });
+
   test.describe('Baseline panel', () => {
     test('Baseline time picker', async ({ exploreProfilesPage }) => {
       await exploreProfilesPage.selectService('pyroscope'); // clears the flame graph ranges

--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneComparePanel/SceneComparePanel.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneComparePanel/SceneComparePanel.tsx
@@ -515,6 +515,7 @@ export class SceneComparePanel extends SceneObjectBase<SceneComparePanelState> {
     const styles = useStyles2(getStyles, color);
 
     const filtersVariable = sceneGraph.findByKey(model, filterKey) as FiltersVariable;
+    const timeRange = sceneGraph.getTimeRange(model);
 
     return (
       <div className={styles.panel} data-testid={`panel-${target}`}>
@@ -542,7 +543,7 @@ export class SceneComparePanel extends SceneObjectBase<SceneComparePanelState> {
         </div>
 
         <div className={styles.filter}>
-          <filtersVariable.Component model={filtersVariable} />
+          <filtersVariable.Component model={filtersVariable} timeRange={timeRange} />
         </div>
 
         <div className={styles.timeseries}>{timeseries && <timeseries.Component model={timeseries} />}</div>

--- a/src/pages/ProfilesExplorerView/domain/variables/FiltersVariable/FiltersVariable.tsx
+++ b/src/pages/ProfilesExplorerView/domain/variables/FiltersVariable/FiltersVariable.tsx
@@ -1,6 +1,12 @@
 import { AdHocVariableFilter } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { AdHocFiltersVariable, SceneComponentProps, sceneGraph, SceneObject } from '@grafana/scenes';
+import {
+  AdHocFiltersVariable,
+  SceneComponentProps,
+  sceneGraph,
+  SceneObject,
+  SceneTimeRangeLike,
+} from '@grafana/scenes';
 import { CompleteFilters } from '@shared/components/QueryBuilder/domain/types';
 import { QueryBuilder } from '@shared/components/QueryBuilder/QueryBuilder';
 import { buildFilterExpressionParts } from '@shared/components/SavedSearches/utils';
@@ -17,6 +23,14 @@ import {
 import { convertPyroscopeToVariableFilter } from './filters-ops';
 
 const FILTERS_LABEL_DEFAULT = 'Filters';
+
+type TimeRangeProp = {
+  /**
+   * The diff view scopes each compare panel to its own time range, which this variable cannot resolve from its
+   * position in the scene graph: it is owned by SceneProfilesExplorer, above the panels.
+   */
+  timeRange?: SceneTimeRangeLike;
+};
 
 export class FiltersVariable extends AdHocFiltersVariable {
   static DEFAULT_VALUE = [];
@@ -86,7 +100,15 @@ export class FiltersVariable extends AdHocFiltersVariable {
     });
   };
 
-  static Component = ({ model }: SceneComponentProps<AdHocFiltersVariable & { onChangeQuery?: any }>) => {
+  /** Widens the props: the `SceneComponentWrapper` returned by the base class forwards extra props to `Component` below. */
+  get Component(): (props: SceneComponentProps<this> & TimeRangeProp) => React.ReactElement | null {
+    return super.Component;
+  }
+
+  static Component = ({
+    model,
+    timeRange,
+  }: SceneComponentProps<AdHocFiltersVariable & { onChangeQuery?: any }> & TimeRangeProp) => {
     const { key } = model.useState();
 
     const query = useBuildPyroscopeQuery(model, key as string);
@@ -95,7 +117,10 @@ export class FiltersVariable extends AdHocFiltersVariable {
       .findByKeyAndType(model, 'dataSource', ProfilesDataSourceVariable)
       .useState();
 
-    const { from, to } = sceneGraph.getTimeRange(model).state.value;
+    // subscribing keeps the available label values in sync with the time range, instead of waiting for an unrelated re-render
+    const {
+      value: { from, to },
+    } = (timeRange ?? sceneGraph.getTimeRange(model)).useState();
 
     return (
       <QueryBuilder


### PR DESCRIPTION
### ✨ Description

Fixes: #821

The baseline and comparison filter variables are owned by `SceneProfilesExplorer`, so `sceneGraph.getTimeRange()` resolves the app-level time range for both of them and the comparison panel's own range never reached its label value lookups. Each compare panel now passes its resolved time range down to its filters; subscribing to it also means the values refresh when the range changes, instead of waiting for an unrelated re-render.

- [x] This pull request was substantially generated with AI assistance ([GenAI policy](https://github.com/grafana/profiles-drilldown/blob/main/docs/genai.md))

### 🧪 How to test?



New E2E test in `diff-flame-graph.spec.ts`: it moves only the comparison panel to a range the static test data doesn't cover, and expects no filter suggestions there while the baseline keeps its own.

**Before**

https://github.com/user-attachments/assets/225f5709-cec2-499d-8c0b-622899a58d0c

**After**


https://github.com/user-attachments/assets/93a72be1-060f-4169-810b-b09bf672a212


