### PR TITLE
feat(call-tree): remove feature flag (default=on)

### DIFF
--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -16,7 +16,7 @@ services:
       GF_INSTALL_PLUGINS: grafana-llm-app
       OPENAI_API_KEY: $OPENAI_API_KEY
       OPENAI_ORGANIZATION_ID: $OPENAI_ORGANIZATION_ID
-      GF_FEATURE_TOGGLES_ENABLE: ${GF_FEATURE_TOGGLES_ENABLE:-metricsFromProfiles,flameGraphWithCallTree,localizationForPlugins,profilesHeatmap}
+      GF_FEATURE_TOGGLES_ENABLE: ${GF_FEATURE_TOGGLES_ENABLE:-metricsFromProfiles,localizationForPlugins,profilesHeatmap}
 
   qdrant:
     image: qdrant/qdrant:v1.17.0@sha256:f1c7272cdac52b38c1a0e89313922d940ba50afd90d593a1605dbbc214e66ffb

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
@@ -12,10 +12,7 @@ import {
 import { Spinner, useStyles2, useTheme2 } from '@grafana/ui';
 import { useMaxNodesFromUrl } from '@shared/domain/url-params/useMaxNodesFromUrl';
 import { useToggleSidePanel } from '@shared/domain/useToggleSidePanel';
-import {
-  useFlagFlameGraphWithCallTree,
-  useFlagMetricsFromProfiles,
-} from '@shared/infrastructure/featureFlags/featureFlags';
+import { useFlagMetricsFromProfiles } from '@shared/infrastructure/featureFlags/featureFlags';
 import { getProfileMetric, ProfileMetricId } from '@shared/infrastructure/profile-metrics/getProfileMetric';
 import { useFetchPluginSettings } from '@shared/infrastructure/settings/useFetchPluginSettings';
 import { DomainHookReturnValue } from '@shared/types/DomainHookReturnValue';
@@ -200,7 +197,6 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
 
   static Component = ({ model }: SceneComponentProps<SceneFlameGraph>) => {
     const styles = useStyles2(getStyles);
-    const flameGraphWithCallTree = useFlagFlameGraphWithCallTree();
     const metricsFromProfiles = useFlagMetricsFromProfiles();
 
     const spanSelector = getSceneVariableValue(model, 'spanSelector');
@@ -303,7 +299,7 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
                 />
               }
               keepFocusOnDataChange
-              enableNewUI={flameGraphWithCallTree}
+              enableNewUI={true}
             />
           )}
         </Panel>

--- a/src/shared/components/FlameGraph/FlameGraph.tsx
+++ b/src/shared/components/FlameGraph/FlameGraph.tsx
@@ -1,7 +1,6 @@
 import { createTheme } from '@grafana/data';
 import { FlameGraph as GrafanaFlameGraph, Props } from '@grafana/flamegraph';
 import { useTheme2 } from '@grafana/ui';
-import { useFlagFlameGraphWithCallTree } from '@shared/infrastructure/featureFlags/featureFlags';
 import React, { memo, useMemo } from 'react';
 
 import type { FlamebearerProfile } from '../../types/FlamebearerProfile';
@@ -27,7 +26,6 @@ function FlameGraphComponent({
   getExtraContextMenuButtons,
   showAnalyzeWithAssistant,
 }: FlameGraphProps) {
-  const flameGraphWithCallTree = useFlagFlameGraphWithCallTree();
   const { isLight } = useTheme2();
   const getTheme = () => createTheme({ colors: { mode: isLight ? 'light' : 'dark' } });
 
@@ -52,7 +50,7 @@ function FlameGraphComponent({
       getExtraContextMenuButtons={getExtraContextMenuButtons}
       keepFocusOnDataChange
       showAnalyzeWithAssistant={showAnalyzeWithAssistant}
-      enableNewUI={flameGraphWithCallTree}
+      enableNewUI={true}
     />
   );
 }

--- a/src/shared/infrastructure/featureFlags/featureFlags.tsx
+++ b/src/shared/infrastructure/featureFlags/featureFlags.tsx
@@ -9,7 +9,6 @@ import { getPluginOpenFeatureBoolean } from './openFeature';
  *
  * @see https://github.com/grafana/grafana/blob/main/contribute/feature-toggles.md
  */
-const flameGraphWithCallTreeKey = 'flameGraphWithCallTree' as keyof FeatureToggles;
 const metricsFromProfilesKey = 'metricsFromProfiles' as keyof FeatureToggles;
 const grafanaAssistantInProfilesDrilldownKey = 'grafanaAssistantInProfilesDrilldown' as keyof FeatureToggles;
 const profilesHeatmapKey = 'profilesHeatmap' as keyof FeatureToggles;
@@ -18,10 +17,6 @@ export const QUERY_LIBRARY_FEATURE_FLAG_KEY = 'queryLibrary' as const;
 const queryLibraryKey: keyof FeatureToggles = QUERY_LIBRARY_FEATURE_FLAG_KEY;
 const kgAnnotationsInPyroscopeKey = 'kgAnnotationsInPyroscope' as keyof FeatureToggles;
 const feedbackButtonKey = 'feedbackButton' as keyof FeatureToggles;
-
-export function useFlagFlameGraphWithCallTree(): boolean {
-  return useBooleanFlagDetails(flameGraphWithCallTreeKey, false).value;
-}
 
 export function useFlagMetricsFromProfiles(): boolean {
   return useBooleanFlagDetails(metricsFromProfilesKey, false).value;


### PR DESCRIPTION
The call tree UI has been at 100% rollout for a while. This removes our local dependency on the `flameGraphWithCallTree` flag and always enables the new flame graph UI, ahead of the flag being removed from grafana/grafana core (grafana/grafana#130584).