### PR TITLE
chore(ci): add cp-update workflow with GitHub App token broker

### DIFF
--- a/.github/workflows/cp-update.yml
+++ b/.github/workflows/cp-update.yml
@@ -1,0 +1,25 @@
+name: Create Plugin Update
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *' # run once a month on the 1st day
+
+permissions: {}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # required for create-github-app-token OIDC auth
+    steps:
+      - id: get-github-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1 (2026-06-01)
+        with:
+          github_app: grafana-plugins-platform-bot
+
+      - uses: grafana/plugin-actions/create-plugin-update@18c6da61002740639bf0322e1a756366d98f5b81 # create-plugin-update/v2.0.4 (2026-08-25)
+        with:
+          token: ${{ steps.get-github-token.outputs.token }}
+          node-version: '22'


### PR DESCRIPTION
## Summary 📝

- Add a `cp-update.yml` (Create Plugin Update) workflow — profiles-drilldown didn't have one — that mints a scoped `grafana-plugins-platform-bot` token via `create-github-app-token` and runs `create-plugin-update` v2.0.4 with `node-version: '22'`, matching traces-drilldown's workflow (grafana/traces-drilldown#868).

> [!IMPORTANT]
> Merge after grafana/deployment_tools#711686, which adds the `Create Plugin Update` GitHub App config entry for `profiles-drilldown` — without it, the token broker has no permission to mint a token for this workflow and the monthly job will fail.

## Test 🧪

- [x] Diffed the new workflow against traces-drilldown's merged `.github/workflows/cp-update.yml` to confirm identical action pins and permissions
- [x] Confirmed `permissions: {}` at workflow level with explicit `contents: read` / `id-token: write` at job level, required for OIDC app-token auth


