### PR TITLE
fix(deps): remediate smol-toml vulnerability

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,7 @@ overrides:
   uuid: '>=11.1.1'
   ws: '>=8.21.3'
   browserslist: '>=4.28.7'
+  smol-toml: '>=1.7.1'
 
 importers:
 
@@ -5651,8 +5652,8 @@ packages:
     peerDependencies:
       immutable: ~5.1.9
 
-  smol-toml@1.6.1:
-    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+  smol-toml@1.8.0:
+    resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
     engines: {node: '>= 18'}
 
   source-map-js@1.2.1:
@@ -11452,7 +11453,7 @@ snapshots:
       picocolors: 1.1.1
       picomatch: 4.0.4
       pretty-ms: 9.3.0
-      smol-toml: 1.6.1
+      smol-toml: 1.8.0
       strip-json-comments: 5.0.1
       summary: 2.1.0
       typescript: 5.6.2
@@ -12693,7 +12694,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  smol-toml@1.6.1: {}
+  smol-toml@1.8.0: {}
 
   source-map-js@1.2.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,6 +53,7 @@ overrides:
   uuid: '>=11.1.1'
   ws: '>=8.21.3'
   browserslist: '>=4.28.7'
+  smol-toml: '>=1.7.1'
 minimumReleaseAgeExclude:
   # Renovate security update: pnpm@11.11.0
   - pnpm@11.11.0


### PR DESCRIPTION
## Summary
- Overrides `smol-toml` to `>=1.7.1`, resolving `knip`'s transitive dependency to 1.8.0
- Fixes high-severity GHSA-7w5x-hrqm-74c2
- Leaves React Router on Grafana-compatible v6; this PR remains draft

## Security/applicability rationale
`GHSA-jjmj-jmhj-qwj2` is absent with `react-router-dom` 6.30.6. The remaining React Router advisories only advertise a v7 fix, which would mismatch Grafana's v6 runtime. Routing targets here are constants, same-origin pathname/search values, or query-only objects; SSR hydration is not used.

## Test plan
- [x] `pnpm install --no-frozen-lockfile`
- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `pnpm audit` confirms the high finding is resolved

## Known remaining
- GHSA-wrjc-x8rr-h8h6 (moderate): no v6 patch; no untrusted redirect target found
- GHSA-337j-9hxr-rhxg (moderate): SSR-only; plugin is browser-only