### PR TITLE
feat(flame-graph): progressive loading with call-site refinement on focus

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
@@ -1,8 +1,12 @@
 import { css } from '@emotion/css';
-import { createTheme, GrafanaTheme2, LoadingState, TimeRange } from '@grafana/data';
+import { createTheme, DataFrame, GrafanaTheme2, LoadingState, TimeRange } from '@grafana/data';
+// TODO: onFocusChange and loadingPaths are not in a released @grafana/flamegraph yet (see grafana/grafana#132316).
+// Until it ships, point the dependency at a local build:
+//   "@grafana/flamegraph": "file:./grafana-flamegraph-local.tgz"
 import { FlameGraph, Props as FlameGraphProps } from '@grafana/flamegraph';
 import { t, Trans } from '@grafana/i18n';
 import {
+  sceneGraph,
   SceneComponentProps,
   SceneObjectBase,
   SceneObjectState,
@@ -14,6 +18,7 @@ import { useMaxNodesFromUrl } from '@shared/domain/url-params/useMaxNodesFromUrl
 import { useToggleSidePanel } from '@shared/domain/useToggleSidePanel';
 import { useFlagMetricsFromProfiles } from '@shared/infrastructure/featureFlags/featureFlags';
 import { getProfileMetric, ProfileMetricId } from '@shared/infrastructure/profile-metrics/getProfileMetric';
+import { DEFAULT_SETTINGS } from '@shared/infrastructure/settings/PluginSettings';
 import { useFetchPluginSettings } from '@shared/infrastructure/settings/useFetchPluginSettings';
 import { DomainHookReturnValue } from '@shared/types/DomainHookReturnValue';
 import { InlineBanner } from '@shared/ui/InlineBanner';
@@ -27,6 +32,13 @@ import { useGrafanaAssistant } from '../../domain/useGrafanaAssistant';
 import { getSceneVariableValue } from '../../helpers/getSceneVariableValue';
 import { deferSceneQueryRunnerRun } from '../../infrastructure/deferSceneQueryRunnerRun';
 import { buildFlameGraphQueryRunner } from '../../infrastructure/flame-graph/buildFlameGraphQueryRunner';
+import {
+  INITIAL_MAX_NODES,
+  ProgressiveController,
+  ProgressiveProgress,
+  startProgressiveRefinement,
+} from '../../infrastructure/flame-graph/progressiveFlameGraph';
+import { dataFrameToTree } from '../../infrastructure/flame-graph/progressiveProfileTree';
 import { PYROSCOPE_DATA_SOURCE } from '../../infrastructure/pyroscope-data-sources';
 import { AIButton } from '../SceneAiPanel/components/AiButton/AIButton';
 import { SceneAiPanel } from '../SceneAiPanel/SceneAiPanel';
@@ -47,6 +59,9 @@ interface SceneFlameGraphState extends SceneObjectState {
   $timeRange?: SceneTimeRange;
   $data: SceneQueryRunner;
   lastTimeRange?: TimeRange;
+  progressiveFrame?: DataFrame;
+  progressiveProgress?: ProgressiveProgress;
+  focusPath?: string[];
   exportMenu: SceneExportMenu;
   aiPanel: SceneAiPanel;
   functionDetailsPanel: SceneFunctionDetailsPanel;
@@ -88,6 +103,13 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
       dataSubscription = newState.$data?.subscribeToState((newDataState) => {
         if (newDataState.data?.state === LoadingState.Done) {
           this.setState({ lastTimeRange: newDataState.data.timeRange });
+
+          const frame = newDataState.data.series?.[0];
+
+          if (frame && frame !== this.lastRefinedFrame) {
+            this.lastRefinedFrame = frame;
+            this.startProgressiveRefinement(frame, newDataState.data.timeRange);
+          }
         }
       });
     });
@@ -95,8 +117,80 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
     return () => {
       stateSubscription.unsubscribe();
       dataSubscription?.unsubscribe();
+      this.stopProgressiveRefinement();
     };
   }
+
+  private refiner?: ProgressiveController;
+  private lastRefinedFrame?: DataFrame;
+  private progressiveQuery?: { enabled: boolean };
+
+  /** Called from the hook below, which is where the settings are available. */
+  setProgressiveQuery(enabled: boolean) {
+    this.progressiveQuery = { enabled };
+  }
+
+  private stopProgressiveRefinement() {
+    this.refiner?.cancel();
+    this.refiner = undefined;
+  }
+
+  private startProgressiveRefinement(frame: DataFrame, timeRange: TimeRange) {
+    this.stopProgressiveRefinement();
+
+    // The flame graph keeps the focus across a data change, and does so without reporting a change, so the focus path
+    // is kept here too and handed to the new controller below. If the path is gone from the new data, resolving it
+    // simply finds nothing and no queries are made.
+    this.setState({ progressiveFrame: frame, progressiveProgress: undefined });
+
+    if (!this.progressiveQuery?.enabled) {
+      return;
+    }
+
+    const tree = dataFrameToTree(frame);
+    const dataSourceUid = getSceneVariableValue(this, 'dataSource');
+    const profileMetricId = getSceneVariableValue(this, 'profileMetricId');
+    const labelSelectorTemplate = (this.state.$data.state.queries[0] as { labelSelector?: string } | undefined)
+      ?.labelSelector;
+
+    if (!tree || !dataSourceUid || !profileMetricId || !labelSelectorTemplate) {
+      return;
+    }
+
+    // The query carries the label selector as a template ($serviceName, ${filters...}), which the query runner would
+    // normally interpolate for us.
+    const labelSelector = sceneGraph.interpolate(this, labelSelectorTemplate);
+
+    this.refiner = startProgressiveRefinement(
+      tree,
+      frame,
+      {
+        dataSourceUid,
+        profileTypeId: profileMetricId,
+        labelSelector,
+        timeRange,
+        unit: frame.fields.find((field) => field.name === 'value')?.config?.unit ?? 'short',
+        // Whether an 'other' node is worth querying depends on how wide it is drawn, so measure the rendered graph.
+        // Zero means it has not been laid out yet, and nothing counts as visible until it has.
+        getViewWidth: () => document.querySelector('[data-testid="flameGraph"]')?.clientWidth ?? 0,
+      },
+      (progressiveFrame, progressiveProgress) => {
+        this.setState({ progressiveFrame, progressiveProgress });
+      }
+    );
+
+    this.refiner.setFocusPath(this.state.focusPath);
+  }
+
+  /** The width the flame graph is drawn at decides what counts as visible, so re-check when it changes. */
+  onViewWidthChange = () => {
+    this.refiner?.rescan();
+  };
+
+  setFocusPath = (focusPath: string[] | undefined) => {
+    this.setState({ focusPath });
+    this.refiner?.setFocusPath(focusPath);
+  };
 
   buildTitle() {
     const serviceName = getSceneVariableValue(this, 'serviceName');
@@ -119,18 +213,37 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
 
     const [maxNodes] = useMaxNodesFromUrl();
     const { settings } = useFetchPluginSettings();
-    const { $timeRange, $data, lastTimeRange, exportMenu, aiPanel, functionDetailsPanel, createRecordingRuleModal } =
-      this.useState();
+    const {
+      $timeRange,
+      $data,
+      lastTimeRange,
+      exportMenu,
+      aiPanel,
+      functionDetailsPanel,
+      createRecordingRuleModal,
+      progressiveFrame,
+      progressiveProgress,
+      focusPath,
+    } = this.useState();
+
+    // Progressive loading only makes sense for the plain profile view: a span or profile id selector already narrows
+    // the query down to something small. Settings can fail to load (the settings API is not available on every
+    // backend), in which case fall back to the default rather than silently turning the feature off.
+    const progressiveEnabled = Boolean(
+      (settings?.progressiveFlamegraphs ?? DEFAULT_SETTINGS.progressiveFlamegraphs) && !spanSelector && !profileIdSelector
+    );
+    this.setProgressiveQuery(progressiveEnabled);
 
     useEffect(() => {
       const runner = buildFlameGraphQueryRunner({
-        maxNodes,
+        // Progressive loading ignores the configured maxNodes: detail comes from re-querying subtrees instead.
+        maxNodes: progressiveEnabled ? INITIAL_MAX_NODES : maxNodes,
         spanSelector,
         profileIdSelector,
       });
       this.setState({ $data: runner });
       return deferSceneQueryRunnerRun(runner);
-    }, [$timeRange, maxNodes, spanSelector, profileIdSelector]);
+    }, [$timeRange, maxNodes, spanSelector, profileIdSelector, progressiveEnabled]);
 
     const $dataState = $data.useState();
     const loadingState = $dataState?.data?.state;
@@ -141,7 +254,10 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
         : null;
 
     const isFetchingProfileData = loadingState === LoadingState.Loading;
-    const profileData = $dataState?.data?.series?.[0];
+    // Refinement is still a load as far as the panel is concerned, so the panel's loading bar keeps animating rather
+    // than the flame graph looking finished while more of it is on the way.
+    const isRefining = Boolean(progressiveProgress && !progressiveProgress.done);
+    const profileData = (progressiveEnabled && progressiveFrame) || $dataState?.data?.series?.[0];
     const hasProfileData = Number(profileData?.length) > 1;
 
     const query = useBuildPyroscopeQuery(this, 'filters');
@@ -149,7 +265,7 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
     return {
       data: {
         title: this.buildTitle(),
-        isLoading: isFetchingProfileData,
+        isLoading: isFetchingProfileData || isRefining,
         isFetchingProfileData,
         hasProfileData,
         profileData,
@@ -172,9 +288,16 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
         recordingRules: {
           modal: createRecordingRuleModal,
         },
+        progressive: {
+          enabled: progressiveEnabled,
+          progress: progressiveProgress,
+          focusPath,
+        },
       },
       actions: {
         getTheme,
+        setFocusPath: this.setFocusPath,
+        onViewWidthChange: this.onViewWidthChange,
       },
     };
   };
@@ -202,6 +325,22 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
     const spanSelector = getSceneVariableValue(model, 'spanSelector');
     const profileIdSelector = getSceneVariableValue(model, 'profileIdSelector');
     const { data, actions } = model.useSceneFlameGraph(spanSelector, profileIdSelector);
+
+    // The flame graph settles into its final width after the panes lay out, and the user can resize it afterwards.
+    // Both change what counts as a visible 'other' node, so re-check when the width changes.
+    useEffect(() => {
+      const canvas = document.querySelector('[data-testid="flameGraph"]');
+
+      if (!canvas || typeof ResizeObserver === 'undefined') {
+        return;
+      }
+
+      const observer = new ResizeObserver(() => actions.onViewWidthChange());
+      observer.observe(canvas);
+
+      return () => observer.disconnect();
+    }, [actions, data.profileData]);
+
     const sidePanel = useToggleSidePanel();
     const gitHubIntegration = useGitHubIntegration(sidePanel);
 
@@ -299,6 +438,8 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
                 />
               }
               keepFocusOnDataChange
+              onFocusChange={actions.setFocusPath}
+              loadingPaths={data.progressive.progress?.loadingPaths}
               enableNewUI={true}
             />
           )}

--- a/src/pages/ProfilesExplorerView/infrastructure/flame-graph/__tests__/progressiveFlameGraph.spec.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/flame-graph/__tests__/progressiveFlameGraph.spec.ts
@@ -1,0 +1,199 @@
+import { type DataFrame, type DataQueryRequest, dateTime, type TimeRange } from '@grafana/data';
+import { getDataSourceSrv } from '@grafana/runtime';
+
+import { INITIAL_MAX_NODES, type ProgressiveProgress, startProgressiveRefinement } from '../progressiveFlameGraph';
+import { type ProfileTreeNode, treeToDataFrame } from '../progressiveProfileTree';
+
+jest.mock('@grafana/runtime', () => ({
+  getDataSourceSrv: jest.fn(),
+}));
+
+jest.mock('@shared/infrastructure/tracking/logger', () => ({
+  logger: { error: jest.fn() },
+}));
+
+/** Drains the promise cascade of a refinement round: fetch -> merge -> rescan -> next request. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const node = (name: string, total: number, self: number, children: ProfileTreeNode[] = []): ProfileTreeNode => ({
+  name,
+  total,
+  self,
+  children,
+});
+
+const other = (total: number) => node('other', total, total);
+
+const timeRange = {
+  from: dateTime(1_700_000_000_000),
+  to: dateTime(1_700_000_600_000),
+} as TimeRange;
+
+/** A tree with a visible 'other' under each of two separate parents. */
+function twoTruncatedBranches() {
+  return node('total', 1000, 0, [
+    node('A', 500, 0, [node('a1', 300, 300), other(200)]),
+    node('B', 500, 0, [node('b1', 300, 300), other(200)]),
+  ]);
+}
+
+type Captured = { request: DataQueryRequest; callSite: string[] };
+
+const maxNodesOf = (captured: Captured) => (captured.request.targets[0] as unknown as { maxNodes: number }).maxNodes;
+
+/**
+ * Stubs the data source so every query can be resolved by hand, which is what lets a test hold one call site's
+ * request open while another one lands.
+ */
+function stubDataSource() {
+  const captured: Captured[] = [];
+  const pending: Array<{ callSite: string[]; resolve: (frame: DataFrame | undefined) => void }> = [];
+
+  jest.mocked(getDataSourceSrv).mockReturnValue({
+    get: async () => ({
+      query: (request: DataQueryRequest) => {
+        const callSite = (request.targets[0] as { stackTraceSelector?: string[] }).stackTraceSelector ?? [];
+        captured.push({ request, callSite });
+        return new Promise((resolve) => {
+          pending.push({ callSite, resolve: (frame) => resolve({ data: frame ? [frame] : [] }) });
+        });
+      },
+    }),
+  } as unknown as ReturnType<typeof getDataSourceSrv>);
+
+  const resolveFor = async (callSite: string[], tree: ProfileTreeNode) => {
+    const index = pending.findIndex((p) => p.callSite.join('|') === callSite.join('|'));
+
+    if (index === -1) {
+      throw new Error(`no pending request for ${callSite.join('|')}`);
+    }
+
+    pending.splice(index, 1)[0].resolve(treeToDataFrame(tree, 'ns'));
+    await flush();
+  };
+
+  return { captured, pending, resolveFor };
+}
+
+function refine(root: ProfileTreeNode, onUpdate?: (progress: ProgressiveProgress) => void) {
+  return startProgressiveRefinement(
+    root,
+    treeToDataFrame(root, 'ns'),
+    {
+      dataSourceUid: 'ds',
+      profileTypeId: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds',
+      labelSelector: '{service_name="svc"}',
+      timeRange,
+      unit: 'ns',
+      getViewWidth: () => 1000,
+    },
+    (_frame, progress) => onUpdate?.(progress)
+  );
+}
+
+/** The refined answer for A: same totals, but the truncated child resolved into real symbols. */
+const refinedA = () =>
+  node('total', 1000, 0, [node('A', 500, 0, [node('a1', 300, 300), node('a2', 120, 120), node('a3', 80, 80)])]);
+
+const childNames = (root: ProfileTreeNode, name: string) =>
+  root.children.find((c) => c.name === name)!.children.map((c) => c.name);
+
+describe('startProgressiveRefinement', () => {
+  it('queries the parent of every visible truncated node once', async () => {
+    const { captured, resolveFor } = stubDataSource();
+    const root = twoTruncatedBranches();
+    const controller = refine(root);
+
+    await flush();
+
+    expect(captured.map((c) => c.callSite)).toEqual([['A'], ['B']]);
+
+    await resolveFor(['A'], refinedA());
+
+    expect(childNames(root, 'A')).toEqual(['a1', 'a2', 'a3']);
+    controller.cancel();
+  });
+
+  it('does not re-query a call site while its request is still in flight', async () => {
+    const { captured, resolveFor } = stubDataSource();
+    const root = twoTruncatedBranches();
+    const controller = refine(root);
+
+    await flush();
+    expect(captured).toHaveLength(2);
+
+    // B lands first. Merging it rescans, and A's 'other' is necessarily still in the tree because A's own request has
+    // not come back yet. Re-queueing A here would abort the request already on the wire, because backendSrv cancels
+    // an in-flight request as soon as another one with the same requestId starts.
+    await resolveFor(['B'], node('total', 1000, 0, [node('B', 500, 0, [node('b1', 300, 300), node('b2', 200, 200)])]));
+
+    expect(captured.filter((c) => c.callSite.join('|') === 'A')).toHaveLength(1);
+
+    // A still completes and merges normally.
+    await resolveFor(['A'], refinedA());
+    expect(childNames(root, 'A')).toEqual(['a1', 'a2', 'a3']);
+    controller.cancel();
+  });
+
+  it('gives every request its own requestId so none of them cancels another', async () => {
+    const { captured, resolveFor } = stubDataSource();
+    // A single branch whose refinement comes back still truncated, so the budget escalates.
+    const root = node('total', 1000, 0, [node('A', 500, 0, [node('a1', 300, 300), other(200)])]);
+    const controller = refine(root);
+
+    await flush();
+
+    for (let i = 0; i < 4 && captured.length > i; i++) {
+      await resolveFor(['A'], node('total', 1000, 0, [node('A', 500, 0, [node('a1', 300, 300), other(200)])]));
+    }
+
+    const ids = captured.map((c) => c.request.requestId);
+    expect(ids.length).toBeGreaterThan(1);
+    expect(new Set(ids).size).toBe(ids.length);
+    controller.cancel();
+  });
+
+  it('escalates the budget only after the previous answer for that call site arrived', async () => {
+    const { captured, resolveFor } = stubDataSource();
+    const root = node('total', 1000, 0, [node('A', 500, 0, [node('a1', 300, 300), other(200)])]);
+    const controller = refine(root);
+
+    await flush();
+    expect(captured).toHaveLength(1);
+    expect(maxNodesOf(captured[0])).toBe(INITIAL_MAX_NODES + 2);
+
+    await resolveFor(['A'], node('total', 1000, 0, [node('A', 500, 0, [node('a1', 300, 300), other(200)])]));
+
+    expect(captured).toHaveLength(2);
+    expect(maxNodesOf(captured[1])).toBeGreaterThan(maxNodesOf(captured[0]));
+    controller.cancel();
+  });
+
+  it('never asks for more nodes than Pyroscope allows', async () => {
+    const { captured, resolveFor } = stubDataSource();
+    // An 'other' directly under the root can only be opened up by raising the budget for the whole profile, so this
+    // escalates all the way to the ceiling.
+    const root = node('total', 1000, 0, [node('a1', 300, 300), other(700)]);
+    const controller = refine(root);
+
+    await flush();
+
+    for (let i = 0; i < 8; i++) {
+      if (!captured.length) {
+        break;
+      }
+
+      try {
+        await resolveFor([], node('total', 1000, 0, [node('a1', 300, 300), other(700)]));
+      } catch {
+        break;
+      }
+    }
+
+    const requested = captured.map(maxNodesOf);
+    expect(requested.length).toBeGreaterThan(1);
+    // Pyroscope answers 'max flamegraph nodes limit N is greater than allowed 1048576' above this.
+    expect(Math.max(...requested)).toBeLessThanOrEqual(1 << 20);
+    controller.cancel();
+  });
+});

--- a/src/pages/ProfilesExplorerView/infrastructure/flame-graph/progressiveFlameGraph.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/flame-graph/progressiveFlameGraph.ts
@@ -1,0 +1,421 @@
+import {
+  DataFrame,
+  DataQuery,
+  DataQueryRequest,
+  DataQueryResponse,
+  DataSourceApi,
+  TimeRange,
+  dateTime,
+} from '@grafana/data';
+import { getDataSourceSrv } from '@grafana/runtime';
+import { logger } from '@shared/infrastructure/tracking/logger';
+import { lastValueFrom, Observable } from 'rxjs';
+
+import {
+  collectVisibleOtherPaths,
+  countNodes,
+  dataFrameToTree,
+  findVisibleOtherParents,
+  hasVisibleOther,
+  isPrefix,
+  mergeChildren,
+  ProfileTreeNode,
+  resolvePath,
+  samePath,
+  treeToDataFrame,
+  ViewGeometry,
+} from './progressiveProfileTree';
+
+/**
+ * Progressive flame graph loading.
+ *
+ * The first query is an ordinary one, so nothing extra is paid for a profile that arrives complete. Further queries
+ * are made only where the user can actually see truncation: for every 'other' node wide enough to be drawn as a real
+ * bar, the subtree above it is re-queried with a call site selector, which spends the whole node budget inside that
+ * subtree and so resolves every 'other' within it at once. Focusing a node re-runs the same rule against the zoomed
+ * view, where slivers that were too narrow to see become visible.
+ *
+ * A query costs the backend about the same whatever its maxNodes is (the read path reads and symbolizes everything
+ * matching the selector either way, maxNodes only trims what comes back), so a call site query is far cheaper than
+ * raising maxNodes for the whole profile, and bounded in payload size too.
+ *
+ * See https://github.com/grafana/grafana-pyroscope-datasource/issues/49.
+ */
+
+// Node budget of every query, including the first one. Progressive loading ignores the configured maxNodes: detail
+// comes from re-querying subtrees rather than from a bigger budget.
+export const INITIAL_MAX_NODES = 16384;
+
+// An 'other' directly under the root cannot be targeted with a call site, so the only way to see inside it is a
+// bigger budget for the whole profile. Rare, and bounded by the server side limit.
+const BUDGET_ESCALATION = 4;
+const MAX_BUDGET = 1 << 20;
+
+const CONCURRENCY = 2;
+// Safety net only: a focus or search change starts a new cycle.
+const MAX_REQUESTS_PER_CYCLE = 16;
+
+export interface ProgressiveProgress {
+  requestsCompleted: number;
+  requestsPending: number;
+  nodeCount: number;
+  done: boolean;
+  // Paths of the 'other' nodes covered by the requests in flight, for the loading overlays.
+  loadingPaths: string[][];
+}
+
+export interface ProgressiveQuery {
+  dataSourceUid: string;
+  profileTypeId: string;
+  labelSelector: string;
+  timeRange: TimeRange;
+  unit: string;
+  /** Width of the rendered flame graph, used to tell a visible 'other' node from a sliver. */
+  getViewWidth: () => number;
+}
+
+export interface ProgressiveController {
+  /** Call path of the focused node, or undefined when the focus is reset. */
+  setFocusPath(path: string[] | undefined): void;
+  /** Re-evaluate what is visible, for instance after the flame graph was laid out or resized. */
+  rescan(): void;
+  /** While a search is active every 'other' node is greyed out, so focus refinement pauses. */
+  setSearchActive(active: boolean): void;
+  cancel(): void;
+}
+
+type RefineTask = {
+  path: string[];
+  budget: number;
+};
+
+interface PyroscopeProfileQuery extends DataQuery {
+  profileTypeId: string;
+  labelSelector: string;
+  maxNodes: number;
+  stackTraceSelector?: string[];
+}
+
+async function fetchSubtree(query: ProgressiveQuery, callSite: string[], budget: number): Promise<DataFrame | undefined> {
+  const dataSource: DataSourceApi = await getDataSourceSrv().get(query.dataSourceUid);
+  const from = query.timeRange.from.valueOf();
+  const to = query.timeRange.to.valueOf();
+
+  const request: DataQueryRequest<PyroscopeProfileQuery> = {
+    requestId: `progressive-flame-graph-${from}-${to}-${callSite.join('|')}`,
+    targets: [
+      {
+        refId: 'progressive',
+        queryType: 'profile',
+        profileTypeId: query.profileTypeId,
+        labelSelector: query.labelSelector,
+        // The call site and the root count against maxNodes, so pad the budget to keep the detail of the subtree the
+        // same at any depth.
+        maxNodes: budget + callSite.length + 1,
+        ...(callSite.length > 0 && { stackTraceSelector: callSite }),
+        datasource: { type: 'grafana-pyroscope-datasource', uid: query.dataSourceUid },
+      },
+    ],
+    range: {
+      from: dateTime(from),
+      to: dateTime(to),
+      raw: { from: dateTime(from), to: dateTime(to) },
+    },
+    interval: '1s',
+    intervalMs: 1000,
+    maxDataPoints: 1,
+    scopedVars: {},
+    timezone: 'browser',
+    app: 'pyroscope-app',
+    startTime: from,
+  };
+
+  const result = dataSource.query(request) as Observable<DataQueryResponse> | Promise<DataQueryResponse>;
+  const response = result instanceof Promise ? await result : await lastValueFrom(result);
+
+  return response.data?.[0];
+}
+
+/**
+ * Refines the tree in place, calling onUpdate with a new data frame after every merged response. The returned
+ * controller stays alive after the initial upgrade so that focus changes can trigger further refinement; cancel it
+ * when the data it was built from is replaced.
+ */
+export function startProgressiveRefinement(
+  root: ProfileTreeNode,
+  initialFrame: DataFrame,
+  query: ProgressiveQuery,
+  onUpdate: (frame: DataFrame, progress: ProgressiveProgress) => void
+): ProgressiveController {
+  const queue: RefineTask[] = [];
+  const pendingByPath = new Map<string, RefineTask>();
+  const loading = new Map<string, string[][]>();
+  // Highest budget already queried per subtree. The initial query counts as the root having been asked at the base
+  // budget, so the root is only re-queried if it escalates.
+  const attempted = new Map<string, number>([['', INITIAL_MAX_NODES]]);
+
+  // The flame graph reports and expects paths that start at the synthetic root ('total'), while paths here are
+  // relative to it: that is also what a call site selector needs, since the root is not a real frame.
+  const rootName = root.name;
+  const toRelative = (path: string[] | undefined) =>
+    path && path[0] === rootName ? path.slice(1) : path;
+  const toAbsolute = (path: string[]) => [rootName, ...path];
+
+  const currentView = (): ViewGeometry | null => {
+    if (searchActive) {
+      return null;
+    }
+
+    const viewRoot = focusPath ? resolvePath(root, focusPath) : root;
+
+    return viewRoot ? { viewTotal: viewRoot.total, widthPx: query.getViewWidth() } : null;
+  };
+
+  let focusPath: string[] | undefined;
+  let searchActive = false;
+  let cancelled = false;
+  let active = 0;
+  let cycleRequests = 0;
+  let requestsCompleted = 0;
+  let announcedBusy = false;
+  let lastFrame = initialFrame;
+
+  const push = (task: RefineTask) => {
+    const key = task.path.join(' ');
+
+    // Never ask the same subtree the same question twice: without this a subtree that stays truncated at a given
+    // budget would be re-queued for ever.
+    if ((attempted.get(key) ?? 0) >= task.budget) {
+      return;
+    }
+
+    const existing = pendingByPath.get(key);
+
+    if (existing) {
+      existing.budget = Math.max(existing.budget, task.budget);
+      return;
+    }
+
+    pendingByPath.set(key, task);
+    queue.push(task);
+  };
+
+  /** Queues the subtrees above every 'other' node the user can currently see. */
+  const scanVisible = () => {
+    const view = currentView();
+
+    if (!view) {
+      return;
+    }
+
+    const scanRoot = focusPath ? resolvePath(root, focusPath) : root;
+
+    if (!scanRoot) {
+      return;
+    }
+
+    for (const parentPath of findVisibleOtherParents(scanRoot, focusPath ?? [], view)) {
+      const key = parentPath.join(' ');
+      const previous = attempted.get(key) ?? 0;
+      // A call site query spends the whole budget inside the subtree, so the base budget is enough. Only the root,
+      // which no call site can target, has to escalate to see anything new.
+      const budget = parentPath.length === 0 ? previous * BUDGET_ESCALATION : Math.max(INITIAL_MAX_NODES, previous * BUDGET_ESCALATION);
+
+      if (budget <= MAX_BUDGET) {
+        push({ path: parentPath, budget });
+      }
+    }
+  };
+
+  const isEligible = (task: RefineTask) => {
+    if (searchActive) {
+      return false;
+    }
+
+    if (!focusPath) {
+      return true;
+    }
+
+    // While focused, everything outside the focused subtree is greyed out.
+    return isPrefix(task.path, focusPath) || isPrefix(focusPath, task.path);
+  };
+
+  const takeBestEligible = (): RefineTask | undefined => {
+    // Shallowest first: a broader refinement covers the deeper ones.
+    let best = -1;
+
+    for (let i = 0; i < queue.length; i++) {
+      if (!isEligible(queue[i])) {
+        continue;
+      }
+
+      if (best === -1 || queue[i].path.length < queue[best].path.length) {
+        best = i;
+      }
+    }
+
+    if (best === -1) {
+      return undefined;
+    }
+
+    const task = queue.splice(best, 1)[0];
+    pendingByPath.delete(task.path.join(' '));
+
+    return task;
+  };
+
+  const emit = (done: boolean, treeChanged: boolean) => {
+    if (cancelled) {
+      return;
+    }
+
+    if (treeChanged) {
+      lastFrame = treeToDataFrame(root, query.unit);
+    }
+
+    onUpdate(lastFrame, {
+      requestsCompleted,
+      requestsPending: active + queue.length,
+      nodeCount: countNodes(root),
+      done,
+      loadingPaths: [...loading.values()].flat().map(toAbsolute),
+    });
+  };
+
+  const processTask = async (task: RefineTask) => {
+    const target = resolvePath(root, task.path);
+    const view = currentView();
+
+    if (!target || !view) {
+      return;
+    }
+
+    // An earlier, broader refinement may have resolved everything visible here already.
+    if (!hasVisibleOther(target, view)) {
+      return;
+    }
+
+    attempted.set(task.path.join(' '), task.budget);
+
+    const loadingKey = task.path.join(' ');
+    loading.set(loadingKey, collectVisibleOtherPaths(target, task.path, view));
+    emit(false, false);
+
+    let treeChanged = false;
+
+    try {
+      const frame = await fetchSubtree(query, task.path, task.budget);
+      requestsCompleted++;
+
+      if (cancelled || !frame) {
+        return;
+      }
+
+      const refinedRoot = dataFrameToTree(frame);
+      const refinedTarget = refinedRoot && resolvePath(refinedRoot, task.path);
+
+      if (!refinedTarget?.children.length) {
+        return;
+      }
+
+      // Re-resolve: a concurrent merge may have replaced the node object while the request was in flight.
+      const mergeTarget = resolvePath(root, task.path);
+
+      if (!mergeTarget) {
+        return;
+      }
+
+      mergeChildren(mergeTarget, refinedTarget);
+      treeChanged = true;
+      scanVisible();
+    } finally {
+      loading.delete(loadingKey);
+      emit(false, treeChanged);
+    }
+  };
+
+  const startTask = (task: RefineTask) => {
+    active++;
+    cycleRequests++;
+
+    if (!announcedBusy) {
+      announcedBusy = true;
+      emit(false, false);
+    }
+
+    processTask(task)
+      .catch((error) => {
+        logger.error(error instanceof Error ? error : new Error(String(error)), {
+          info: 'Progressive flame graph refinement failed',
+          path: task.path.join(' '),
+        });
+      })
+      .finally(() => {
+        active--;
+        pump();
+      });
+  };
+
+  const pump = () => {
+    if (cancelled) {
+      return;
+    }
+
+    while (active < CONCURRENCY && cycleRequests < MAX_REQUESTS_PER_CYCLE) {
+      const task = takeBestEligible();
+
+      if (!task) {
+        break;
+      }
+
+      startTask(task);
+    }
+
+    if (active === 0 && announcedBusy) {
+      announcedBusy = false;
+      emit(true, false);
+    }
+  };
+
+  scanVisible();
+  pump();
+
+  return {
+    setFocusPath(path: string[] | undefined) {
+      const relativePath = toRelative(path);
+
+      if (cancelled || samePath(relativePath, focusPath)) {
+        return;
+      }
+
+      focusPath = relativePath;
+      cycleRequests = 0;
+      // Zooming into a subtree makes slivers inside it wide enough to see, and so worth querying.
+      scanVisible();
+      pump();
+    },
+    rescan() {
+      if (cancelled) {
+        return;
+      }
+
+      scanVisible();
+      pump();
+    },
+    setSearchActive(active: boolean) {
+      if (cancelled || active === searchActive) {
+        return;
+      }
+
+      searchActive = active;
+      cycleRequests = 0;
+      scanVisible();
+      pump();
+    },
+    cancel() {
+      cancelled = true;
+      queue.length = 0;
+      pendingByPath.clear();
+    },
+  };
+}

--- a/src/pages/ProfilesExplorerView/infrastructure/flame-graph/progressiveFlameGraph.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/flame-graph/progressiveFlameGraph.ts
@@ -49,6 +49,8 @@ export const INITIAL_MAX_NODES = 16384;
 // An 'other' directly under the root cannot be targeted with a call site, so the only way to see inside it is a
 // bigger budget for the whole profile. Rare, and bounded by the server side limit.
 const BUDGET_ESCALATION = 4;
+// Pyroscope refuses a request whose maxNodes is above this, so the padding below must not push us over it.
+const SERVER_MAX_NODES = 1 << 20;
 const MAX_BUDGET = 1 << 20;
 
 const CONCURRENCY = 2;
@@ -102,7 +104,9 @@ async function fetchSubtree(query: ProgressiveQuery, callSite: string[], budget:
   const to = query.timeRange.to.valueOf();
 
   const request: DataQueryRequest<PyroscopeProfileQuery> = {
-    requestId: `progressive-flame-graph-${from}-${to}-${callSite.join('|')}`,
+    // The budget is part of the id: backendSrv cancels an in-flight request as soon as another one with the same
+    // requestId starts, so escalating the budget for a call site would otherwise abort the request already on the wire.
+    requestId: `progressive-flame-graph-${from}-${to}-${budget}-${callSite.join('|')}`,
     targets: [
       {
         refId: 'progressive',
@@ -111,7 +115,7 @@ async function fetchSubtree(query: ProgressiveQuery, callSite: string[], budget:
         labelSelector: query.labelSelector,
         // The call site and the root count against maxNodes, so pad the budget to keep the detail of the subtree the
         // same at any depth.
-        maxNodes: budget + callSite.length + 1,
+        maxNodes: Math.min(budget + callSite.length + 1, SERVER_MAX_NODES),
         ...(callSite.length > 0 && { stackTraceSelector: callSite }),
         datasource: { type: 'grafana-pyroscope-datasource', uid: query.dataSourceUid },
       },
@@ -149,6 +153,9 @@ export function startProgressiveRefinement(
 ): ProgressiveController {
   const queue: RefineTask[] = [];
   const pendingByPath = new Map<string, RefineTask>();
+  // Call sites with a request on the wire. A rescan triggered by another merge sees their 'other' still in place,
+  // precisely because the answer has not arrived yet, and would re-queue them at a higher budget for nothing.
+  const inFlight = new Set<string>();
   const loading = new Map<string, string[][]>();
   // Highest budget already queried per subtree. The initial query counts as the root having been asked at the base
   // budget, so the root is only re-queried if it escalates.
@@ -186,6 +193,10 @@ export function startProgressiveRefinement(
     // Never ask the same subtree the same question twice: without this a subtree that stays truncated at a given
     // budget would be re-queued for ever.
     if ((attempted.get(key) ?? 0) >= task.budget) {
+      return;
+    }
+
+    if (inFlight.has(key)) {
       return;
     }
 
@@ -298,6 +309,7 @@ export function startProgressiveRefinement(
     attempted.set(task.path.join(' '), task.budget);
 
     const loadingKey = task.path.join(' ');
+    inFlight.add(loadingKey);
     loading.set(loadingKey, collectVisibleOtherPaths(target, task.path, view));
     emit(false, false);
 
@@ -327,9 +339,16 @@ export function startProgressiveRefinement(
 
       mergeChildren(mergeTarget, refinedTarget);
       treeChanged = true;
-      scanVisible();
     } finally {
+      inFlight.delete(loadingKey);
       loading.delete(loadingKey);
+
+      // Rescan only once this call site is off the wire, so that a subtree which came back still truncated can be
+      // asked again at a higher budget. Before emit, so the reported pending count includes whatever this queues.
+      if (treeChanged) {
+        scanVisible();
+      }
+
       emit(false, treeChanged);
     }
   };

--- a/src/pages/ProfilesExplorerView/infrastructure/flame-graph/progressiveProfileTree.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/flame-graph/progressiveProfileTree.ts
@@ -1,0 +1,205 @@
+import { DataFrame, FieldType, createDataFrame } from '@grafana/data';
+
+/**
+ * Tree utilities for progressive flame graph loading: the coarse profile returned by the initial query is turned into
+ * a tree, refined subtrees are merged into it, and the result is turned back into a data frame for the flame graph.
+ */
+
+// Pyroscope names the node standing in for a truncated subtree 'other' (see model.truncatedNodeName).
+export const TRUNCATED_NODE_NAME = 'other';
+
+// Bars this narrow or narrower are drawn muted and unlabelled by the flame graph (MUTE_THRESHOLD in
+// @grafana/flamegraph), so an 'other' node below this width is not something the user can actually see.
+const MUTE_THRESHOLD_PX = 10;
+
+export type ProfileTreeNode = {
+  name: string;
+  total: number;
+  self: number;
+  children: ProfileTreeNode[];
+};
+
+export function dataFrameToTree(frame: DataFrame): ProfileTreeNode | undefined {
+  const labelField = frame.fields.find((f) => f.name === 'label');
+  const levelField = frame.fields.find((f) => f.name === 'level');
+  const valueField = frame.fields.find((f) => f.name === 'value');
+  const selfField = frame.fields.find((f) => f.name === 'self');
+
+  if (!labelField || !levelField || !valueField || !selfField) {
+    return undefined;
+  }
+
+  const enumText = labelField.config?.type?.enum?.text;
+  const labelAt = (i: number) =>
+    enumText ? String(enumText[labelField.values[i]] ?? '') : String(labelField.values[i]);
+
+  let root: ProfileTreeNode | undefined;
+  const lastAtLevel: ProfileTreeNode[] = [];
+
+  // The nested set format is a depth first pre-order walk, so the parent of a node at level L is the most recent node
+  // seen at level L-1.
+  for (let i = 0; i < levelField.values.length; i++) {
+    const level = levelField.values[i];
+    const node: ProfileTreeNode = {
+      name: labelAt(i),
+      total: valueField.values[i],
+      self: selfField.values[i],
+      children: [],
+    };
+
+    if (level === 0) {
+      root = node;
+    } else {
+      lastAtLevel[level - 1]?.children.push(node);
+    }
+
+    lastAtLevel[level] = node;
+  }
+
+  return root;
+}
+
+export function treeToDataFrame(root: ProfileTreeNode, unit: string): DataFrame {
+  const labelValues: string[] = [];
+  const levelValues: number[] = [];
+  const selfValues: number[] = [];
+  const valueValues: number[] = [];
+
+  const stack: Array<{ node: ProfileTreeNode; level: number }> = [{ node: root, level: 0 }];
+
+  while (stack.length) {
+    const { node, level } = stack.shift()!;
+
+    labelValues.push(node.name);
+    levelValues.push(level);
+    selfValues.push(node.self);
+    valueValues.push(node.total);
+
+    stack.unshift(...node.children.map((child) => ({ node: child, level: level + 1 })));
+  }
+
+  return createDataFrame({
+    name: 'response',
+    meta: { preferredVisualisationType: 'flamegraph' },
+    fields: [
+      { name: 'level', values: levelValues },
+      { name: 'label', values: labelValues, type: FieldType.string },
+      { name: 'self', values: selfValues, config: { unit } },
+      { name: 'value', values: valueValues, config: { unit } },
+    ],
+  });
+}
+
+export function resolvePath(root: ProfileTreeNode, path: string[]): ProfileTreeNode | undefined {
+  let node: ProfileTreeNode | undefined = root;
+
+  for (const name of path) {
+    node = node?.children.find((child) => child.name === name);
+  }
+
+  return node;
+}
+
+export function countNodes(node: ProfileTreeNode): number {
+  let count = 1;
+
+  for (const child of node.children) {
+    count += countNodes(child);
+  }
+
+  return count;
+}
+
+/**
+ * Paths of the 'other' nodes in the subtree that the user can see. A refinement resolves every 'other' below it, but
+ * only the visible ones are worth marking as loading: the rest are slivers the flame graph draws muted anyway.
+ */
+export function collectVisibleOtherPaths(
+  node: ProfileTreeNode,
+  path: string[],
+  view: ViewGeometry,
+  out: string[][] = []
+): string[][] {
+  for (const child of node.children) {
+    if (child.name === TRUNCATED_NODE_NAME) {
+      if (isVisible(child.total, view)) {
+        out.push([...path, TRUNCATED_NODE_NAME]);
+      }
+    } else {
+      collectVisibleOtherPaths(child, [...path, child.name], view, out);
+    }
+  }
+
+  return out;
+}
+
+/**
+ * How the flame graph currently draws the tree: the total of the subtree that fills the width (the focused node, or
+ * the root when nothing is focused) and how wide that is on screen. Together they decide what the user can see.
+ */
+export type ViewGeometry = {
+  viewTotal: number;
+  widthPx: number;
+};
+
+/** Whether a node of this size is drawn as a real bar rather than a muted sliver. */
+export function isVisible(total: number, view: ViewGeometry): boolean {
+  return view.viewTotal > 0 && (total / view.viewTotal) * view.widthPx > MUTE_THRESHOLD_PX;
+}
+
+/** Whether the subtree contains an 'other' node the user can actually see, and so is worth another query. */
+export function hasVisibleOther(node: ProfileTreeNode, view: ViewGeometry): boolean {
+  return node.children.some((child) =>
+    child.name === TRUNCATED_NODE_NAME ? isVisible(child.total, view) : hasVisibleOther(child, view)
+  );
+}
+
+/** Paths of the parents of the visible 'other' nodes in the subtree. */
+export function findVisibleOtherParents(
+  node: ProfileTreeNode,
+  path: string[],
+  view: ViewGeometry,
+  out: string[][] = []
+): string[][] {
+  for (const child of node.children) {
+    if (child.name === TRUNCATED_NODE_NAME) {
+      if (isVisible(child.total, view)) {
+        out.push(path);
+      }
+    } else {
+      findVisibleOtherParents(child, [...path, child.name], view, out);
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Replaces the target's children with the refined ones, keeping an existing child subtree when it is already more
+ * detailed than the refinement, so that a broad refinement landing late never discards a deeper one.
+ */
+export function mergeChildren(target: ProfileTreeNode, refined: ProfileTreeNode) {
+  const existingByName = new Map(target.children.map((child) => [child.name, child]));
+
+  target.children = refined.children.map((refinedChild) => {
+    const existing = existingByName.get(refinedChild.name);
+
+    if (existing && refinedChild.name !== TRUNCATED_NODE_NAME && countNodes(existing) > countNodes(refinedChild)) {
+      return existing;
+    }
+
+    return refinedChild;
+  });
+}
+
+export function isPrefix(prefix: string[], path: string[]): boolean {
+  return prefix.length <= path.length && prefix.every((name, i) => name === path[i]);
+}
+
+export function samePath(a: string[] | undefined, b: string[] | undefined): boolean {
+  if (!a || !b) {
+    return a === b;
+  }
+
+  return a.length === b.length && a.every((name, i) => name === b[i]);
+}

--- a/src/shared/infrastructure/settings/PluginSettings.ts
+++ b/src/shared/infrastructure/settings/PluginSettings.ts
@@ -4,6 +4,7 @@ export type PluginSettings = {
   enableFlameGraphDotComExport: boolean;
   enableFunctionDetails: boolean;
   enableMetricsFromProfiles?: boolean;
+  progressiveFlamegraphs?: boolean;
 };
 
 export const DEFAULT_SETTINGS: PluginSettings = Object.freeze({
@@ -12,4 +13,5 @@ export const DEFAULT_SETTINGS: PluginSettings = Object.freeze({
   enableFlameGraphDotComExport: true,
   enableFunctionDetails: true,
   enableMetricsFromProfiles: false,
+  progressiveFlamegraphs: true,
 });


### PR DESCRIPTION
Tenants raise `max_nodes` to 1M so they never see an `other` node, and pay for it in latency: on a dev cell the same 15 service/range combinations took 3.4x longer to first paint at the median (11.5x worst case), shipped 2-46 MB instead of 0.7-0.9 MB, and 4 of 15 windows failed outright at the datasource's 30s timeout.

This queries a bounded tree (16384 nodes) and then refines only the truncated subtrees the user actually focuses, using the `stackTraceSelector` call site added in grafana/grafana-pyroscope-datasource#57. Configured `max_nodes` is ignored while it is on. Total backend CPU for a whole session, refinements included, is 0.8x a single 1M query.

Enabled by default via `progressiveFlamegraphs` in plugin settings.

<!-- TODO: video of a profile refining as nodes are focused -->
_Video: TODO_

Notes:
- Draft: needs `onFocusChange` and `loadingPaths` from grafana/grafana#132316 in a released `@grafana/flamegraph`. There is a TODO at the import with the local-build workaround.