### PR TITLE
chore(i18n): remove github_board_id from i18n-crowdin-download.yml

### DIFF
--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -35,5 +35,4 @@ jobs:
           crowdin_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).CROWDIN_TOKEN }}
           crowdin_project_id: 42
           pr_labels: 'i18n'
-          github_board_id: 42
           github_repo_token: ${{ steps.get-github-app-token.outputs.token }}


### PR DESCRIPTION
### ✨ Description

This pull request makes a minor update to the i18n Crowdin download workflow by removing the unused `github_board_id` parameter from the job configuration.

Fixes: https://github.com/grafana/profiles-drilldown/actions/runs/34599065650/job/103261674649
```bash
Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
Run octokit/graphql-action@51bf543c240dcd14761320e2efc625dc32ec0d32
    
  query getProjectId($org: String!, $project_number: Int!){
    organization(login: $org) {
      projectV2(number: $project_number) {
        title
        id
      }
    }
  }
  > org: grafana
  > project_number: 42
  > mediaType: undefined
  Error: Request failed due to following response errors:
   - Could not resolve to a ProjectV2 with the number 42.
```

Fixes: <!-- Link to the issue this PR fixes -->
Related issue(s): <!-- Link to the issue this PR is related to but does not resolve it -->

<!-- Summary of the most important changes, the choices made (and why) and any other relevant info that will help your reviewers -->

- [ ] This pull request was substantially generated with AI assistance ([GenAI policy](https://github.com/grafana/profiles-drilldown/blob/main/docs/genai.md))

### 🧪 How to test?

<!-- Steps required to test the PR or pointer to the automated tests -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->
